### PR TITLE
Perfectly invertible STFT

### DIFF
--- a/asteroid/filterbanks/stft_fb.py
+++ b/asteroid/filterbanks/stft_fb.py
@@ -36,15 +36,17 @@ class STFTFB(Filterbank):
             self.window = window
         # Create and normalize DFT filters (can be overcomplete)
         filters = np.fft.fft(np.eye(n_filters))
-        filters /= (.5 * np.sqrt(kernel_size * n_filters / self.stride))
+        filters /= (0.5 * np.sqrt(kernel_size * n_filters / self.stride))
+
         # Keep only the windowed centered part to save computation.
         lpad = int((n_filters - kernel_size) // 2)
         rpad = int(n_filters - kernel_size - lpad)
         indexes = list(range(lpad, n_filters - rpad))
         filters = np.vstack([np.real(filters[:self.cutoff, indexes]),
                              np.imag(filters[:self.cutoff, indexes])])
+
         filters[0, :] /= np.sqrt(2)
-        filters[-1, :] /= np.sqrt(2)
+        filters[n_filters // 2, :] /= np.sqrt(2)
         filters = torch.from_numpy(filters * self.window).unsqueeze(1).float()
         self.register_buffer('_filters', filters)
 

--- a/tests/filterbanks/stft_test.py
+++ b/tests/filterbanks/stft_test.py
@@ -2,16 +2,18 @@ import pytest
 import torch
 from torch import testing
 import numpy as np
+from scipy.signal import get_window
 
 from asteroid.filterbanks import Encoder, Decoder, STFTFB
 from asteroid.filterbanks import make_enc_dec
+from asteroid.filterbanks.stft_fb import perfect_synthesis_window
 
 
 def fb_config_list():
     keys = ['n_filters', 'kernel_size', 'stride']
     param_list = [
-        [512, 256, 128],  # Usual STFT, 50% overlap
-        [512, 256, 64],  # Usual STFT, 25% overlap
+        [256, 256, 128],  # Usual STFT, 50% overlap
+        [256, 256, 64],  # Usual STFT, 25% overlap
         [512, 32, 16],  # Overcomplete STFT, 50% overlap
     ]
     return [dict(zip(keys, values)) for values in param_list]
@@ -40,7 +42,6 @@ def test_stft_windows(fb_config):
 
 @pytest.mark.parametrize("fb_config", fb_config_list())
 def test_filter_shape(fb_config):
-    # for fb_config in fb_config_list:
     # Instantiate STFT
     fb = STFTFB(**fb_config)
     # Check filter shape.
@@ -49,21 +50,14 @@ def test_filter_shape(fb_config):
 
 
 @pytest.mark.parametrize("fb_config", fb_config_list())
-def test_istft(fb_config):
-    """ Without dividing by the overlap-added window, the STFT iSTFT cannot
-    pass the unit test. Uncomment the plot to see the perfect resynthesis."""
+def test_perfect_istft_default_parameters(fb_config):
+    """ Unit test perfect reconstruction with default values. """
     kernel_size = fb_config['kernel_size']
     enc, dec = make_enc_dec('stft', **fb_config)
     inp_wav = torch.randn(2, 1, 32000)
     out_wav = dec(enc(inp_wav))[:, :, kernel_size: -kernel_size]
     inp_test = inp_wav[:, :, kernel_size: -kernel_size]
-    # testing.assert_allclose(inp_test,
-    #                         out_wav,
-    #                         rtol=1e-7, atol=1e-3)
-    # import matplotlib.pyplot as plt
-    # plt.plot(inp_test.data.numpy()[0, 0], 'b')
-    # plt.plot(out_wav.data.numpy()[0, 0], 'r')
-    # plt.show()
+    testing.assert_allclose(inp_test, out_wav)
 
 
 @pytest.mark.parametrize('kernel_size', [256])


### PR DESCRIPTION
### What does this PR do?
- Fix some small errors in the STFT computation in `STFTFB` to enable perfect reconstruction with classic sqrt of hanning window in analysis and synthesis. 
- Add the possibilty to compute perfect resynthesis window from a given analysis window and the hop size (close to how `paderbox` handles it @). Compared to usual approaches (compute window square OLA on the whole signal length and divide by it), this doesn't require any additional computation at runtime because the synthesis window is fixed. 
- Unit tests for perfect reconstruction in several common window/kernel size/ stride choices.

STFT is now perfectly stable, let's use it ! :wink: 
For people using it (@sunits, @JorisCos, @popcornell), please rebase master (or merge) when this is merged.  