### PR TITLE
Add support for multichannel convolutions

### DIFF
--- a/asteroid/filterbanks/enc_dec.py
+++ b/asteroid/filterbanks/enc_dec.py
@@ -221,7 +221,7 @@ class Decoder(_EncDec):
             view_as = (-1,) + spec.shape[-2:]
             out = F.conv_transpose1d(spec.view(view_as),
                                      filters, stride=self.stride)
-            return out.view(spec.shape[:-1] + (-1,))
+            return out.view(spec.shape[:-2] + (-1,))
 
 
 class NoEncoder(nn.Module):  # pragma: no cover

--- a/tests/filterbanks/filterbanks_test.py
+++ b/tests/filterbanks/filterbanks_test.py
@@ -33,7 +33,9 @@ def test_fb_def_and_forward_lowdim(fb_class, fb_config):
     inp = torch.randn(1, 1, 32000)
     tf_out = enc(inp)
     # Assert for 2D inputs
-    assert_allclose(enc(inp), enc(inp[0]))
+    with pytest.warns(UserWarning):
+        # STFT(2D) gives 3D and iSTFT(3D) gives 3D. UserWarning about that.
+        assert_allclose(enc(inp), enc(inp[0]))
     # Assert for 1D inputs
     assert_allclose(enc(inp)[0], enc(inp[0, 0]))
 
@@ -43,7 +45,7 @@ def test_fb_def_and_forward_lowdim(fb_class, fb_config):
     out_4d = dec(tf_out_4d)
     assert_allclose(out, out_4d[:, 0])
     # Asser for 2D inputs
-    assert_allclose(out[0], dec(tf_out[0]))
+    assert_allclose(out[0, 0], dec(tf_out[0]))
     assert tf_out.shape[1] == enc.filterbank.n_feats_out
 
 

--- a/tests/filterbanks/filterbanks_test.py
+++ b/tests/filterbanks/filterbanks_test.py
@@ -1,3 +1,4 @@
+import random
 import pytest
 import torch
 from torch.testing import assert_allclose
@@ -23,24 +24,61 @@ def fb_config_list():
 
 @pytest.mark.parametrize("fb_class", [FreeFB, AnalyticFreeFB, ParamSincFB])
 @pytest.mark.parametrize("fb_config", fb_config_list())
-def test_fb_def_and_forward(fb_class, fb_config):
-    """ Test filterbank defintion and encoder/decoder forward."""
+def test_fb_def_and_forward_lowdim(fb_class, fb_config):
+    """ Test filterbank definition and encoder/decoder forward."""
     # Definition
     enc = Encoder(fb_class(**fb_config))
     dec = Decoder(fb_class(**fb_config))
     # Forward
     inp = torch.randn(1, 1, 32000)
     tf_out = enc(inp)
+    # Assert for 2D inputs
+    assert_allclose(enc(inp), enc(inp[0]))
+    # Assert for 1D inputs
+    assert_allclose(enc(inp)[0], enc(inp[0, 0]))
+
     out = dec(tf_out)
-    # 4d forward + unit test
+    # Assert for 4D inputs
     tf_out_4d = tf_out.repeat(1, 2, 1, 1)
     out_4d = dec(tf_out_4d)
     assert_allclose(out, out_4d[:, 0])
-    # Get config tests
-    dec_config = dec.get_config()
-    enc_config = enc.get_config()
-    # N feats out test
+    # Asser for 2D inputs
+    assert_allclose(out[0], dec(tf_out[0]))
     assert tf_out.shape[1] == enc.filterbank.n_feats_out
+
+
+@pytest.mark.parametrize("fb_class", [FreeFB, AnalyticFreeFB, ParamSincFB])
+@pytest.mark.parametrize("fb_config", fb_config_list())
+def test_fb_def_and_forward_all_dims(fb_class, fb_config):
+    """ Test encoder/decoder on other shapes than 3D"""
+    # Definition
+    enc = Encoder(fb_class(**fb_config))
+    dec = Decoder(fb_class(**fb_config))
+
+    # 3D Forward with one channel
+    inp = torch.randn(3, 1, 32000)
+    tf_out = enc(inp)
+    assert tf_out.shape[:2] == (3, enc.filterbank.n_feats_out)
+    out = dec(tf_out)
+    assert out.shape[:-1] == inp.shape[:-1]  # Time axis can differ
+
+
+@pytest.mark.parametrize("fb_class", [FreeFB, AnalyticFreeFB, ParamSincFB])
+@pytest.mark.parametrize("fb_config", fb_config_list())
+@pytest.mark.parametrize("ndim", [2, 3, 4])
+def test_fb_forward_multichannel(fb_class, fb_config, ndim):
+    """ Test encoder/decoder in multichannel setting"""
+    # Definition
+    enc = Encoder(fb_class(**fb_config))
+    dec = Decoder(fb_class(**fb_config))
+    # 3D Forward with several channels
+    tensor_shape = tuple([random.randint(2, 4) for _ in range(ndim)]) + (4000,)
+    inp = torch.randn(tensor_shape)
+    tf_out = enc(inp)
+    assert tf_out.shape[:ndim+1] == (tensor_shape[:-1] +
+                                     (enc.filterbank.n_feats_out,))
+    out = dec(tf_out)
+    assert out.shape[:-1] == inp.shape[:-1]  # Time axis can differ
 
 
 @pytest.mark.parametrize("fb_class", [AnalyticFreeFB, ParamSincFB])


### PR DESCRIPTION
Need feedback on output shapes @popcornell @sunits @JorisCos please !
### What is this PR about 
This adds support to multichannel 1D convolutions and transposed convolutions. It's useful for multichannel or multi-source STFT and iSTFT in particular. 
We also add support for convolution of 1D and 2D signals. Previously only 3D signals of shape `(batch, 1, time)` were supported in `Encoder.forward`. No need for batch or empty channel dimension anymore (but this is still supported) !

```python
import torch
from asteroid.filterbanks import STFTFB, Encoder, Decoder

batch=3
encoder = Encoder(STFTFB(512, 512, 256))
decoder = Decoder(STFTFB(512, 512, 256))

# 1D case : this now works
inp = torch.randn(32000,)
stft = encoder(inp)  # (freq, conv_time)
out =  decoder(stft)  # (1, time)

# 2D case : this also works
inp = torch.randn(batch, 32000)
stft = encoder(inp)   # (batch, freq, conv_time)
out =  decoder(stft)  # (batch, 1, time)

# 3D case with channels : this also works
inp = torch.randn(batch, 3, 32000)
stft = encoder(inp)   # (batch, 3, freq, conv_time)
out =  decoder(stft)  # (batch, 3, time)
```

This is achieved with grouping the non-convoluted dimensions into the batch so we keep `torch`'s efficiency.
All the expected behavior are unit tested.

### Why this choice for the output shapes?
The STFT gives something like this 
```
(time) --> (freq, conv_time)
(1, time) --> (1, freq, conv_time)  # We could squeeze here but I think that's a bad idea.
(1, 1, time) --> (1, freq, conv_time)  # Same as a regular Conv1D
(2, time) --> (2, freq, conv_time)
(2, 1, time) --> (2, freq, conv_time)  # Same as a regular Conv1D
(2, 2, time) --> (2, 2, freq, conv_time)  # Multichannel starts here
(18, 32, 1) --> (18, 32, 1, freq, conv_time)
```
Because `(batch, time)` and `(batch, 1, time)` match to the same stft shape `(batch, freq, conv_time)`, the `Decoder` cannot know from which shape it comes from. What do you think about this? Which choice for the `Decoder`'s output shape? Should we add an `output_dim` argument to the decoder?  

### What remains to be done 
- Take a decision for the iSTFT.
- Update the docs to reflect on the changes (comes on the next PR on filterbanks, with some other cleanups)