### PR TITLE
Add multi-scale spectral loss 

### DIFF
--- a/asteroid/losses/multi_scale_spectral.py
+++ b/asteroid/losses/multi_scale_spectral.py
@@ -1,0 +1,96 @@
+import torch
+import torch.nn as nn
+from torch.nn.modules.loss import _Loss
+from asteroid.filterbanks import STFTFB, Encoder
+from asteroid.filterbanks.inputs_and_masks import take_mag
+
+EPS = 1e-8
+
+
+class MultiScaleSpectral(_Loss):
+    """ Measure multi-scale spectral loss as described in [1]
+
+    Args:
+        n_filters (list): list containing the number of filter desired for
+            each STFT
+        windows_size (list): list containing the size of the window desired for
+            each STFT
+        hops_size (list): list containing the size of the hop desired for
+            each STFT
+
+    Shape:
+        est_targets (:class:`torch.Tensor`): Expected shape
+            [batch, , time]. Batch of target estimates.
+        targets (:class:`torch.Tensor`): Expected shape
+            [batch, 1, time]. Batch of training targets.
+        alpha (:class'float')
+
+    Returns:
+        :class:`torch.Tensor`: with shape [batch]
+
+    Examples:
+
+        >>> import torch
+        >>> from asteroid.losses import PITLossWrapper
+        >>> targets = torch.randn(10,2,32000)
+        >>> est_targets = torch.randn(10,2,32000)
+        >>> loss_func=PITLossWrapper(MultiScaleSpectral(), mode='wo_src')
+        >>> loss = loss_func(est_targets, targets)
+
+        >>> import torch
+        >>> targets = torch.randn(10,1,32000)
+        >>> est_targets = torch.randn(10,1,32000)
+        >>> loss_func=MultiScaleSpectral()
+        >>> loss = loss_func(est_targets, targets)
+
+
+
+    References:
+        [1] Jesse Engel and Lamtharn (Hanoi) Hantrakul and Chenjie Gu and
+        Adam Roberts
+        DDSP: Differentiable Digital Signal Processing
+        International Conference on Learning Representations
+        ICLR 2020 """
+
+    def __init__(self, n_filters=None, windows_size=None,
+                 hops_size=None, alpha=1.):
+        super(MultiScaleSpectral, self).__init__()
+
+        if windows_size is None:
+            windows_size = [2048, 1024, 512, 256, 128, 64, 32]
+        if n_filters is None:
+            n_filters = [2048, 1024, 512, 256, 128, 64, 32]
+        if hops_size is None:
+            hops_size = [1024, 512, 256, 128, 64, 32, 16]
+
+        self.windows_size = windows_size
+        self.n_filters = n_filters
+        self.hops_size = hops_size
+        self.alpha = alpha
+
+        self.encoders = nn.ModuleList(
+            Encoder(STFTFB(n_filters[i], windows_size[i], hops_size[i])) for i
+            in range(len(self.n_filters)))
+
+    def forward(self, est_target, target):
+        batch_size = est_target.shape[0]
+        est_target = est_target.unsqueeze(1)
+        target = target.unsqueeze(1)
+
+        loss = torch.zeros(batch_size, device=est_target.device)
+        for encoder in self.encoders:
+            loss += self.compute_spectral_loss(encoder, est_target, target)
+        return loss
+
+    def compute_spectral_loss(self, encoder, est_target, target):
+        batch_size = est_target.shape[0]
+        spect_est_target = take_mag(encoder(est_target)).view(batch_size, -1)
+        spect_target = take_mag(encoder(target)).view(batch_size, -1)
+        loss = self.norm1(
+            spect_est_target - spect_target) + self.alpha * self.norm1(
+            torch.log(spect_est_target + EPS) - torch.log(spect_target + EPS))
+        return loss
+
+    @staticmethod
+    def norm1(a):
+        return torch.norm(a, p=1, dim=1)

--- a/asteroid/losses/multi_scale_spectral.py
+++ b/asteroid/losses/multi_scale_spectral.py
@@ -38,8 +38,8 @@ class MultiScaleSpectral(_Loss):
         >>> loss = loss_func(est_targets, targets)
 
         >>> import torch
-        >>> targets = torch.randn(10,1,32000)
-        >>> est_targets = torch.randn(10,1,32000)
+        >>> targets = torch.randn(10,32000)
+        >>> est_targets = torch.randn(10,32000)
         >>> loss_func=MultiScaleSpectral()
         >>> loss = loss_func(est_targets, targets)
 

--- a/tests/losses/loss_functions_test.py
+++ b/tests/losses/loss_functions_test.py
@@ -61,8 +61,8 @@ def test_multi_scale_spectral_PIT(n_src):
 @pytest.mark.parametrize("batch_size", [2, 3, 4])
 def test_multi_scale_spectral_shape(batch_size):
     # Fake targets and estimates
-    targets = torch.randn(batch_size, 1, 32000)
-    est_targets = torch.randn(batch_size, 1, 32000)
+    targets = torch.randn(batch_size, 32000)
+    est_targets = torch.randn(batch_size, 32000)
     # Create PITLossWrapper in 'wo_src' mode
     loss_func = MultiScaleSpectral()
     # Compute the loss

--- a/tests/losses/loss_functions_test.py
+++ b/tests/losses/loss_functions_test.py
@@ -6,6 +6,7 @@ from asteroid.losses import PITLossWrapper
 from asteroid.losses import sdr
 from asteroid.losses import nosrc_mse, pairwise_mse, nonpit_mse
 from asteroid.losses import deep_clustering_loss
+from asteroid.losses.multi_scale_spectral import MultiScaleSpectral
 
 
 @pytest.mark.parametrize("n_src", [2, 3, 4])
@@ -44,3 +45,26 @@ def test_dc(spk_cnt):
     targets = torch.LongTensor(10, 400, 5).random_(0, spk_cnt)
     loss = deep_clustering_loss(embedding, targets, spk_cnt)
     assert loss.shape[0] == 10
+
+
+@pytest.mark.parametrize("n_src", [2, 3, 4])
+def test_multi_scale_spectral_PIT(n_src):
+    # Fake targets and estimates
+    targets = torch.randn(2, n_src, 32000)
+    est_targets = torch.randn(2, n_src, 32000)
+    # Create PITLossWrapper in 'wo_src' mode
+    loss_func = PITLossWrapper(MultiScaleSpectral(), mode='wo_src')
+    # Compute the loss
+    loss = loss_func(targets, est_targets)
+
+
+@pytest.mark.parametrize("batch_size", [2, 3, 4])
+def test_multi_scale_spectral_shape(batch_size):
+    # Fake targets and estimates
+    targets = torch.randn(batch_size, 1, 32000)
+    est_targets = torch.randn(batch_size, 1, 32000)
+    # Create PITLossWrapper in 'wo_src' mode
+    loss_func = MultiScaleSpectral()
+    # Compute the loss
+    loss = loss_func(targets, est_targets)
+    assert loss.shape[0] == batch_size


### PR DESCRIPTION
Content
This adds multi-scale spectral loss as described in [1] in paragraph 4.2.1. The implementation is compatible with the PITLossWrapper module with 'wo_src ' mode.

Also adds 2 unit tests for this loss function 

TODO
Implement 'pairwise' and 'w_src' compatibility for PITLossWrapper module

References
[1] Jesse Engel and Lamtharn (Hanoi) Hantrakul and Chenjie Gu and
Adam Roberts
DDSP: Differentiable Digital Signal Processing
International Conference on Learning Representations
ICLR 2020, https://openreview.net/forum?id=B1x1ma4tDr