### PR TITLE
Fix evaluation bugs

### DIFF
--- a/asteroid/torch_utils.py
+++ b/asteroid/torch_utils.py
@@ -1,5 +1,6 @@
 import torch
 from torch import nn
+from collections import OrderedDict
 
 
 def pad_x_to_y(x, y, axis=-1):
@@ -18,3 +19,57 @@ def pad_x_to_y(x, y, axis=-1):
     inp_len = y.size(axis)
     output_len = x.size(axis)
     return nn.functional.pad(x, [0, inp_len - output_len])
+
+
+def load_state_dict_in(state_dict, model):
+    """ Strictly loads state_dict in model, or the next submodel.
+        Useful to load standalone model after training it with System.
+
+    Args:
+        state_dict (OrderedDict): the state_dict to load.
+        model (torch.nn.Module): the model to load it into
+
+    Returns:
+        torch.nn.Module: model with loaded weights.
+
+    # Note :
+        Keys in a state_dict look like object1.object2.layer_name.weight.etc
+        We first try to load the model in the classic way.
+        If this fail we removes the first left part of the key to obtain
+        object2.layer_name.weight.etc.
+        Blindly loading with strictly=False should be done with some logging
+        of the missing keys in the state_dict and the model.
+
+    """
+    try:
+        # This can fail if the model was included into a bigger nn.Module
+        # object. For example, into System.
+        model.load_state_dict(state_dict, strict=True)
+    except RuntimeError:
+        # keys look like object1.object2.layer_name.weight.etc
+        # The following will remove the first left part of the key to obtain
+        # object2.layer_name.weight.etc.
+        # Blindly loading with strictly=False should be done with some
+        # new_state_dict of the missing keys in the state_dict and the model.
+        new_state_dict = OrderedDict()
+        for k, v in state_dict.items():
+            new_k = k[k.find('.') + 1:]
+            new_state_dict[new_k] = v
+        model.load_state_dict(new_state_dict, strict=True)
+    return model
+
+
+def are_models_equal(model1, model2):
+    """ Check for weights equality between models.
+
+    Args:
+        model1 (nn.Module): model instance to be compared.
+        model2 (nn.Module): second model instance to be compared.
+
+    Returns:
+        bool: Whether all model weights are equal.
+    """
+    for p1, p2 in zip(model1.parameters(), model2.parameters()):
+        if p1.data.ne(p2.data).sum() > 0:
+            return False
+    return True

--- a/egs/dns_challenge/baseline/model.py
+++ b/egs/dns_challenge/baseline/model.py
@@ -11,7 +11,7 @@ from asteroid.filterbanks.inputs_and_masks import apply_real_mask
 from asteroid.filterbanks.inputs_and_masks import apply_mag_mask
 from asteroid.masknn import blocks
 from asteroid.engine.optimizers import make_optimizer
-from asteroid.torch_utils import pad_x_to_y
+from asteroid import torch_utils
 
 
 def make_model_and_optimizer(conf):
@@ -91,7 +91,7 @@ class Model(nn.Module):
     def denoise(self, x):
         estimate_stft = self(x)
         wav = self.decoder(estimate_stft)
-        return pad_x_to_y(wav, x)
+        return torch_utils.pad_x_to_y(wav, x)
 
 
 class SimpleModel(nn.Module):
@@ -179,7 +179,8 @@ def load_best_model(train_conf, exp_dir):
     best_model_path = min(best_k, key=best_k.get)
     # Load checkpoint
     checkpoint = torch.load(best_model_path, map_location='cpu')
-    # Load state_dict into model, strict=False is important here
-    model.load_state_dict(checkpoint['state_dict'], strict=False)
+    # Load state_dict into model.
+    model = torch_utils.load_state_dict_in(checkpoint['state_dict'],
+                                           model)
     model.eval()
     return model

--- a/egs/wham/ConvTasNet/model.py
+++ b/egs/wham/ConvTasNet/model.py
@@ -1,6 +1,10 @@
+import json
+import os
+import torch
 from torch import nn
 
 import asteroid.filterbanks as fb
+from asteroid import torch_utils
 from asteroid.masknn import TDConvNet
 from asteroid.engine.optimizers import make_optimizer
 
@@ -46,3 +50,29 @@ def make_model_and_optimizer(conf):
     # Define optimizer of this model
     optimizer = make_optimizer(model.parameters(), **conf['optim'])
     return model, optimizer
+
+
+def load_best_model(train_conf, exp_dir):
+    """ Load best model after training.
+
+    Args:
+        train_conf (dict): dictionary as expected by `make_model_and_optimizer`
+        exp_dir(str): Experiment directory. Expects to find
+            `'best_k_models.json'` there.
+
+    Returns:
+        nn.Module the best pretrained model according to the val_loss.
+    """
+    # Create the model from recipe-local function
+    model, _ = make_model_and_optimizer(train_conf)
+    # Last best model summary
+    with open(os.path.join(exp_dir, 'best_k_models.json'), "r") as f:
+        best_k = json.load(f)
+    best_model_path = min(best_k, key=best_k.get)
+    # Load checkpoint
+    checkpoint = torch.load(best_model_path, map_location='cpu')
+    # Load state_dict into model.
+    model = torch_utils.load_state_dict_in(checkpoint['state_dict'],
+                                           model)
+    model.eval()
+    return model

--- a/egs/wham/DPRNN/model.py
+++ b/egs/wham/DPRNN/model.py
@@ -1,6 +1,10 @@
+import json
+import os
+import torch
 from torch import nn
 
 import asteroid.filterbanks as fb
+from asteroid import torch_utils
 from asteroid.masknn import DPRNN
 from asteroid.engine.optimizers import make_optimizer
 
@@ -44,3 +48,29 @@ def make_model_and_optimizer(conf):
     # Define optimizer of this model
     optimizer = make_optimizer(model.parameters(), **conf['optim'])
     return model, optimizer
+
+
+def load_best_model(train_conf, exp_dir):
+    """ Load best model after training.
+
+    Args:
+        train_conf (dict): dictionary as expected by `make_model_and_optimizer`
+        exp_dir(str): Experiment directory. Expects to find
+            `'best_k_models.json'` there.
+
+    Returns:
+        nn.Module the best pretrained model according to the val_loss.
+    """
+    # Create the model from recipe-local function
+    model, _ = make_model_and_optimizer(train_conf)
+    # Last best model summary
+    with open(os.path.join(exp_dir, 'best_k_models.json'), "r") as f:
+        best_k = json.load(f)
+    best_model_path = min(best_k, key=best_k.get)
+    # Load checkpoint
+    checkpoint = torch.load(best_model_path, map_location='cpu')
+    # Load state_dict into model.
+    model = torch_utils.load_state_dict_in(checkpoint['state_dict'],
+                                           model)
+    model.eval()
+    return model

--- a/tests/utils/torch_utils_test.py
+++ b/tests/utils/torch_utils_test.py
@@ -1,6 +1,6 @@
 import torch
 import pytest
-
+from torch import nn
 from asteroid import torch_utils
 
 
@@ -16,3 +16,40 @@ def test_pad_fail():
     y = torch.randn(10, 16234, 1)
     with pytest.raises(NotImplementedError):
         padded_x = torch_utils.pad_x_to_y(x, y, axis=1)
+
+
+def test_model_equal():
+    model = nn.Sequential(nn.Linear(10, 10))
+    assert torch_utils.are_models_equal(model, model)
+    model_2 = nn.Sequential(nn.Linear(10, 10))
+    assert not torch_utils.are_models_equal(model, model_2)
+
+
+def test_loader_module():
+    model = nn.Sequential(nn.Linear(10, 10))
+    state_dict = model.state_dict()
+    model_2 = nn.Sequential(nn.Linear(10, 10))
+    model_2 = torch_utils.load_state_dict_in(state_dict, model_2)
+    assert torch_utils.are_models_equal(model, model_2)
+
+
+def test_loader_submodule():
+    class SuperModule(nn.Module):
+        """ nn.Module subclass that holds a model under self.whoever """
+        def __init__(self, sub_model):
+            super().__init__()
+            self.whoever = sub_model
+    model = SuperModule(nn.Sequential(nn.Linear(10, 10)))
+    # Keys in state_dict will be whoever.0.weight, whoever.0.bias
+    state_dict = model.state_dict()
+    # We want to load it in model_2 (has keys 0.weight, 0.bias)
+    model_2 = nn.Sequential(nn.Linear(10, 10))
+    # Keys are not the same, torch raises an error for that.
+    with pytest.raises(RuntimeError):
+        model_2.load_state_dict(state_dict)
+    # We can try loose model loading (assert it doesn't work)
+    model_2.load_state_dict(state_dict, strict=False)
+    assert not torch_utils.are_models_equal(model, model_2)
+    # Apply our workaround torch_utils.load_state_dict_in and assert True.
+    model_2 = torch_utils.load_state_dict_in(state_dict, model_2)
+    assert torch_utils.are_models_equal(model, model_2)


### PR DESCRIPTION
Models where not loaded correctly because of `strict=False` and keys mismatch, my bad. 
- Model loading from a trained `System` is now easy with `torch_utils.load_state_dict_in`. This tries loading the state_dict as is, if it fails, it removes the string subparts corresponding to the upper module. 
Please read the docs and the unit tests, this should be quite clear and if it's not, tell me. 
- Evaluation scripts are updated accordingly to load model correctly 
- load_best_model function got to model.py file in the recipes because it makes more sense IMO
- Also added a `are_models_equal` in torch_utils.py to check if two models have the same weights or not (also unit tested).