### PR TITLE
More complex support

### DIFF
--- a/asteroid/filterbanks/inputs_and_masks.py
+++ b/asteroid/filterbanks/inputs_and_masks.py
@@ -2,7 +2,7 @@ import torch
 EPS = 1e-8
 
 
-def mul_c(inp, other, dim=1):
+def mul_c(inp, other, dim=-2):
     """ Entrywise product for complex valued tensors.
 
     Operands are assumed to have the real parts of each entry followed by the
@@ -45,11 +45,11 @@ def mul_c(inp, other, dim=1):
                       real1 * imag2 + imag1 * real2], dim=dim)
 
 
-def take_reim(x, dim=1):
+def take_reim(x, dim=-2):
     return x
 
 
-def take_mag(x, dim=1):
+def take_mag(x, dim=-2):
     """ Takes the magnitude of a complex tensor.
 
     The operands is assumed to have the real parts of each entry followed by
@@ -82,11 +82,11 @@ def take_mag(x, dim=1):
     return power.pow(0.5)
 
 
-def take_cat(x, dim=1):
+def take_cat(x, dim=-2):
     return torch.cat([take_mag(x, dim=dim), x], dim=dim)
 
 
-def apply_real_mask(tf_rep, mask, dim=1):
+def apply_real_mask(tf_rep, mask, dim=-2):
     """ Applies a real-valued mask to a real-valued representation.
 
     It corresponds to ReIm mask in [1].
@@ -102,7 +102,7 @@ def apply_real_mask(tf_rep, mask, dim=1):
     return tf_rep * mask
 
 
-def apply_mag_mask(tf_rep, mask, dim=1):
+def apply_mag_mask(tf_rep, mask, dim=-2):
     """ Applies a real-valued mask to a complex-valued representation.
 
     If `tf_rep` has 2N elements along `dim`, `mask` has N elements, `mask` is
@@ -139,7 +139,7 @@ def apply_mag_mask(tf_rep, mask, dim=1):
     return tf_rep * mask
 
 
-def apply_complex_mask(tf_rep, mask, dim=1):
+def apply_complex_mask(tf_rep, mask, dim=-2):
     """ Applies a complex-valued mask to a complex-valued representation.
 
     Operands are assumed to have the real parts of each entry followed by the

--- a/asteroid/filterbanks/inputs_and_masks.py
+++ b/asteroid/filterbanks/inputs_and_masks.py
@@ -224,7 +224,6 @@ def from_numpy(array, dim=-2):
         :class:`torch.Tensor`:
             Corresponding torch.Tensor (complex axis in dim `dim`=
     """
-    assert array.dtype is ['complex64', 'complex128'], array.dtype
     return torch.cat([torch.from_numpy(np.real(array)),
                       torch.from_numpy(np.imag(array))], dim=dim)
 

--- a/asteroid/filterbanks/inputs_and_masks.py
+++ b/asteroid/filterbanks/inputs_and_masks.py
@@ -228,6 +228,36 @@ def from_numpy(array, dim=-2):
                       torch.from_numpy(np.imag(array))], dim=dim)
 
 
+def to_torchaudio(tensor, dim=-2):
+    """ Converts complex-like torch tensor to torchaudio style complex tensor.
+
+    Args:
+        tensor (torch.tensor): asteroid-style complex-like torch tensor.
+        dim(int, optional): the frequency (or equivalent) dimension along which
+            real and imaginary values are concatenated.
+
+    Returns:
+        :class:`torch.Tensor`:
+            torchaudio-style complex-like torch tensor.
+    """
+    return torch.stack(torch.chunk(tensor, 2, dim=dim), dim=-1)
+
+
+def from_torchaudio(tensor, dim=-2):
+    """ Converts torchaudio style complex tensor to complex-like torch tensor.
+
+    Args:
+        tensor (torch.tensor): torchaudio-style complex-like torch tensor.
+        dim(int, optional): the frequency (or equivalent) dimension along which
+            real and imaginary values are concatenated.
+
+    Returns:
+        :class:`torch.Tensor`:
+            asteroid-style complex-like torch tensor.
+    """
+    return torch.cat([tensor[..., 0], tensor[..., 1]], dim=dim)
+
+
 def angle(tensor, dim=-2):
     """ Return the angle of the complex-like torch tensor.
 

--- a/tests/filterbanks/inputs_and_masks_test.py
+++ b/tests/filterbanks/inputs_and_masks_test.py
@@ -1,9 +1,10 @@
+import random
 import pytest
 import torch
 from torch.testing import assert_allclose
+import numpy as np
 
 from asteroid import filterbanks as fb
-from asteroid.filterbanks.inputs_and_masks import _masks
 from asteroid.filterbanks import inputs_and_masks
 
 
@@ -95,3 +96,96 @@ def test_cat(encoder_list):
         batch, freq, time = tf_rep.shape
         mag = inputs_and_masks.take_cat(tf_rep, dim=1)
         assert mag.shape == (batch, 3 * (freq // 2), time)
+
+
+@pytest.mark.parametrize("np_torch_tuple", [
+    ([0], [0, 0]),
+    ([1j], [0, 1]),
+    ([-1], [-1, 0]),
+    ([-1j], [0, -1]),
+    ([1 + 1j], [1, 1]),
+])
+@pytest.mark.parametrize("dim", [0, 1, 2])
+def test_to_numpy(np_torch_tuple, dim):
+    """ Test torch --> np conversion (right angles)"""
+    from_np, from_torch = np_torch_tuple
+    if dim == 0:
+        np_array = np.array(from_np)
+        torch_tensor = torch.tensor(from_torch)
+    elif dim == 1:
+        np_array = np.array([from_np])
+        torch_tensor = torch.tensor([from_torch])
+    elif dim == 2:
+        np_array = np.array([[from_np]])
+        torch_tensor = torch.tensor([[from_torch]])
+    else:
+        return
+    np_from_torch = inputs_and_masks.to_numpy(torch_tensor, dim=dim)
+    np.testing.assert_allclose(np_array, np_from_torch)
+
+
+@pytest.mark.parametrize("np_torch_tuple", [
+    ([0], [0, 0]),
+    ([1j], [0, 1]),
+    ([-1], [-1, 0]),
+    ([-1j], [0, -1]),
+    ([1 + 1j], [1, 1]),
+])
+@pytest.mark.parametrize("dim", [0, 1, 2])
+def test_from_numpy(np_torch_tuple, dim):
+    """ Test np --> torch conversion (right angles)"""
+    from_np, from_torch = np_torch_tuple
+    if dim == 0:
+        np_array = np.array(from_np)
+        torch_tensor = torch.tensor(from_torch)
+    elif dim == 1:
+        np_array = np.array([from_np])
+        torch_tensor = torch.tensor([from_torch])
+    elif dim == 2:
+        np_array = np.array([[from_np]])
+        torch_tensor = torch.tensor([[from_torch]])
+    else:
+        return
+    torch_from_np = inputs_and_masks.from_numpy(np_array, dim=dim)
+    np.testing.assert_allclose(torch_tensor, torch_from_np)
+
+
+@pytest.mark.parametrize("dim", [0, 1, 2, 3])
+def test_return_ticket_np_torch(dim):
+    """ Test torch --> np --> torch --> np conversion"""
+    max_tested_ndim = 4
+    # Random tensor shape
+    tensor_shape = [random.randint(1, 10) for _ in range(max_tested_ndim)]
+    # Make sure complex dimension has even shape
+    tensor_shape[dim] = 2 * tensor_shape[dim]
+    complex_tensor = torch.randn(tensor_shape)
+    np_array = inputs_and_masks.to_numpy(complex_tensor, dim=dim)
+    tensor_back = inputs_and_masks.from_numpy(np_array, dim=dim)
+    np_back = inputs_and_masks.to_numpy(tensor_back, dim=dim)
+    # Check torch --> np --> torch
+    assert_allclose(complex_tensor, tensor_back)
+    # Check np --> torch --> np
+    np.testing.assert_allclose(np_array, np_back)
+
+
+@pytest.mark.parametrize("dim", [0, 1, 2, 3])
+def test_angle_mag_recompostion(dim):
+    """ Test complex --> (mag, angle) --> complex conversions"""
+    max_tested_ndim = 4
+    # Random tensor shape
+    tensor_shape = [random.randint(1, 10) for _ in range(max_tested_ndim)]
+    # Make sure complex dimension has even shape
+    tensor_shape[dim] = 2 * tensor_shape[dim]
+    complex_tensor = torch.randn(tensor_shape)
+    phase = inputs_and_masks.angle(complex_tensor, dim=dim)
+    mag = inputs_and_masks.take_mag(complex_tensor, dim=dim)
+    tensor_back = inputs_and_masks.from_mag_and_phase(mag, phase, dim=dim)
+    assert_allclose(complex_tensor, tensor_back)
+
+
+@pytest.mark.parametrize("dim", [0, 1, 2, 3])
+def test_check_complex_error(dim):
+    """ Test error in angle """
+    not_complex = torch.randn(3, 5, 7, 9, 15)
+    with pytest.raises(AssertionError):
+        phase = inputs_and_masks.check_complex(not_complex, dim=dim)

--- a/tests/filterbanks/inputs_and_masks_test.py
+++ b/tests/filterbanks/inputs_and_masks_test.py
@@ -189,3 +189,17 @@ def test_check_complex_error(dim):
     not_complex = torch.randn(3, 5, 7, 9, 15)
     with pytest.raises(AssertionError):
         phase = inputs_and_masks.check_complex(not_complex, dim=dim)
+
+
+@pytest.mark.parametrize("dim", [0, 1, 2, 3])
+def test_torchaudio_format(dim):
+    max_tested_ndim = 4
+    # Random tensor shape
+    tensor_shape = [random.randint(1, 10) for _ in range(max_tested_ndim)]
+    # Make sure complex dimension has even shape
+    tensor_shape[dim] = 2 * tensor_shape[dim]
+    complex_tensor = torch.randn(tensor_shape)
+    ta_tensor = inputs_and_masks.to_torchaudio(complex_tensor, dim=dim)
+    tensor_back = inputs_and_masks.from_torchaudio(ta_tensor, dim=dim)
+    assert_allclose(complex_tensor, tensor_back)
+    assert ta_tensor.shape[-1] == 2


### PR DESCRIPTION
### Context
We are converging on the _complex-like_ representation, which is practical as real and imaginary parts are treated as channels. The shape is `(..., 2*F, ...)` with any number dimensions before the _complex_ dimension. The real and imaginary parts are concatenated on this `2*F` axis.

The main critic against this is that the axis has to be known in order to perform operations on it. On the countrary, `torchaudio` has a `(..., 2)` convention which doesn't have this flaw, but I guess, will require a lot more of reshaping to use it in training etc...

### This PR adds : 
- `check_complex` : checks that the tensor is _complex-like_
- `to_numpy` : converts a  _complex-like_ torch tensor to numpy complex array
- `from_numpy` : converts a np complex array to a  _complex-like_ torch tensor.
- `angle` : returns the angle of a  _complex-like_ torch tensor (like `np.angle`)
- `from_mag_and_phase` : returns a  _complex-like_ torch tensor from magnitude and phase tensors.

And unit tests for all this.
I'll add routines to convert to the `torchaudio` format tomorow probably. 