### PR TITLE
Fix for GPU usage

### DIFF
--- a/asteroid/losses/multi_scale_spectral.py
+++ b/asteroid/losses/multi_scale_spectral.py
@@ -72,6 +72,7 @@ class SingleSrcMultiScaleSpectral(_Loss):
             in range(len(self.n_filters)))
 
     def forward(self, est_target, target):
+        self.encoders.to(est_target.device)
         batch_size = est_target.shape[0]
         est_target = est_target.unsqueeze(1)
         target = target.unsqueeze(1)

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -131,7 +131,7 @@ class PITLossWrapper(nn.Module):
         losses using broadcasting.
         """
         batch_size, n_src, *_ = targets.shape
-        pair_wise_losses = torch.empty(batch_size, n_src, n_src)
+        pair_wise_losses = targets.new_empty(batch_size, n_src, n_src)
         for est_idx, est_src in enumerate(est_targets.transpose(0, 1)):
             for target_idx, target_src in enumerate(targets.transpose(0, 1)):
                 pair_wise_losses[:, est_idx, target_idx] = loss_func(


### PR DESCRIPTION
### Content
Fix the behavior of the `SingleSrcMultiScaleSpectral` loss function when dealing with data coming from a GPU.

### What is wrong now

You need to specify:
`loss_func=PITLossWrapper(SingleSrcMultiScaleSpectral(),pit_from='pw_pt').to(device)`
with `device` a `cuda.device` object matching your targets and estimates `device`. If you don't, encoders in the loss function will be generated with `device= torch.device('cpu')` and your code will break.

### Intended behavior

You should just call `PITLossWrapper(SingleSrcMultiScaleSpectral(),pit_from='pw_pt')`
and the function will choose the `device` according to your targets and estimates.