### PR TITLE
Add `get_metrics` method in asteroid

### DIFF
--- a/asteroid/metrics.py
+++ b/asteroid/metrics.py
@@ -1,0 +1,68 @@
+from .utils import average_arrays_in_dic
+from pb_bss.evaluation import InputMetrics, OutputMetrics
+ALL_METRICS = ['si_sdr', 'sdr', 'sir', 'sar', 'stoi', 'pesq']
+
+
+def get_metrics(mix, clean, estimate, sample_rate=16000, metrics_list='all',
+                average=True, compute_permutation=False):
+    """ Get speech separation/enhancement metrics from mix/clean/estimate.
+
+    Args:
+        mix (np.array): 'Shape(D, N)' or 'Shape(N, )'.
+        clean (np.array): 'Shape(K_source, N)' or 'Shape(N, )'.
+        estimate (np.array): 'Shape(K_target, N)' or 'Shape(N, )'.
+        sample_rate (int): sampling rate of the audio clips.
+        metrics_list (Union [str, list]): List of metrics to compute.
+            Defaults to 'all' (['si_sdr', 'sdr', 'sir', 'sar', 'stoi', 'pesq']).
+        average (bool): Return dict([float]) if True, else dict([array]).
+        compute_permutation (bool): Whether to compute the permutation on
+            estimate sources for the output metrics (default False)
+
+    Returns:
+        dict: Dictionary with all requested metrics, with `'input_'` prefix
+            for metrics at the input (mixture against clean), no prefix at the
+            output (estimate against clean). Output format depends on average.
+
+    Examples:
+        >>> import numpy as np
+        >>> import pprint
+        >>> from asteroid.metrics import get_metrics
+        >>> mix = np.random.randn(1, 16000)
+        >>> clean = np.random.randn(2, 16000)
+        >>> est = np.random.randn(2, 16000)
+        >>> metrics_dict = get_metrics(mix, clean, est, sample_rate=8000,
+        >>>                            metrics_list='all')
+        >>> pprint.pprint(metrics_dict)
+        {'input_pesq': 1.924380898475647,
+         'input_sar': -11.67667585294225,
+         'input_sdr': -14.88667106190552,
+         'input_si_sdr': -52.43849784881705,
+         'input_sir': -0.10419427290163795,
+         'input_stoi': 0.015112115177091223,
+         'pesq': 1.7713886499404907,
+         'sar': -11.610963379923195,
+         'sdr': -14.527246041125844,
+         'si_sdr': -46.26557128489802,
+         'sir': 0.4799929272243427,
+         'stoi': 0.022023073540350643}
+
+    """
+    if metrics_list == 'all':
+        metrics_list = ALL_METRICS
+    # For each utterance, we get a dictionary with the input and output metrics
+    input_metrics = InputMetrics(observation=mix,
+                                 speech_source=clean,
+                                 enable_si_sdr=True,
+                                 sample_rate=sample_rate)
+    utt_metrics = {'input_' + n: input_metrics[n] for n in metrics_list}
+
+    output_metrics = OutputMetrics(speech_prediction=estimate,
+                                   speech_source=clean,
+                                   enable_si_sdr=True,
+                                   sample_rate=sample_rate,
+                                   compute_permutation=compute_permutation)
+    utt_metrics.update(output_metrics[metrics_list])
+    if average is True:
+        return average_arrays_in_dic(utt_metrics)
+    else:
+        return utt_metrics

--- a/asteroid/metrics.py
+++ b/asteroid/metrics.py
@@ -49,6 +49,8 @@ def get_metrics(mix, clean, estimate, sample_rate=16000, metrics_list='all',
     """
     if metrics_list == 'all':
         metrics_list = ALL_METRICS
+    if isinstance(metrics_list, str):
+        metrics_list = [metrics_list]
     # For each utterance, we get a dictionary with the input and output metrics
     input_metrics = InputMetrics(observation=mix,
                                  speech_source=clean,

--- a/egs/wham/ConvTasNet/eval.py
+++ b/egs/wham/ConvTasNet/eval.py
@@ -6,13 +6,13 @@ import yaml
 import json
 import argparse
 import pandas as pd
+from asteroid.metrics import get_metrics
 from tqdm import tqdm
 from pprint import pprint
-from pb_bss.evaluation import InputMetrics, OutputMetrics
 
 from asteroid.losses import PITLossWrapper, pairwise_neg_sisdr
 from asteroid.data.wham_dataset import WhamDataset
-from asteroid.utils import tensors_to_device, average_arrays_in_dic
+from asteroid.utils import tensors_to_device
 
 from model import load_best_model
 
@@ -61,23 +61,9 @@ def main(conf):
         mix_np = mix[None].cpu().data.numpy()
         sources_np = sources.squeeze().cpu().data.numpy()
         est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
-        # For each utterance, we get a dictionary with the mixture path,
-        # the input and output metrics.utt_metrics
-        input_metrics = InputMetrics(observation=mix_np,
-                                     speech_source=sources_np,
-                                     enable_si_sdr=True,
-                                     sample_rate=conf['sample_rate'])
-        utt_metrics = {'input_' + n: input_metrics[n] for n in compute_metrics}
-
-        output_metrics = OutputMetrics(speech_prediction=est_sources_np,
-                                       speech_source=sources_np,
-                                       enable_si_sdr=True,
-                                       sample_rate=conf['sample_rate'],
-                                       compute_permutation=False)
-
-        utt_metrics.update(output_metrics[compute_metrics])
+        utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
+                                  sample_rate=conf['sample_rate'])
         utt_metrics['mix_path'] = test_set.mix[idx][0]
-        utt_metrics = average_arrays_in_dic(utt_metrics)
         series_list.append(pd.Series(utt_metrics))
 
         # Save some examples in a folder. Wav files and metrics as text.

--- a/egs/whamr/TasNet/eval.py
+++ b/egs/whamr/TasNet/eval.py
@@ -9,11 +9,11 @@ import argparse
 import pandas as pd
 from tqdm import tqdm
 from pprint import pprint
-from pb_bss.evaluation import InputMetrics, OutputMetrics
 
 from asteroid.losses import PITLossWrapper, pairwise_neg_sisdr
+from asteroid.metrics import get_metrics
 from asteroid.data import WhamRDataset
-from asteroid.utils import tensors_to_device, average_arrays_in_dic
+from asteroid.utils import tensors_to_device
 
 from model import load_best_model
 warnings.simplefilter("ignore", UserWarning)
@@ -64,23 +64,9 @@ def main(conf):
         mix_np = mix[None].cpu().data.numpy()
         sources_np = sources.squeeze().cpu().data.numpy()
         est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
-        # For each utterance, we get a dictionary with the mixture path,
-        # the input and output metrics.utt_metrics
-        input_metrics = InputMetrics(observation=mix_np,
-                                     speech_source=sources_np,
-                                     enable_si_sdr=True,
-                                     sample_rate=conf['sample_rate'])
-        utt_metrics = {'input_' + n: input_metrics[n] for n in compute_metrics}
-
-        output_metrics = OutputMetrics(speech_prediction=est_sources_np,
-                                       speech_source=sources_np,
-                                       enable_si_sdr=True,
-                                       sample_rate=conf['sample_rate'],
-                                       compute_permutation=False)
-
-        utt_metrics.update(output_metrics[compute_metrics])
+        utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
+                                  sample_rate=conf['sample_rate'])
         utt_metrics['mix_path'] = test_set.mix[idx][0]
-        utt_metrics = average_arrays_in_dic(utt_metrics)
         series_list.append(pd.Series(utt_metrics))
 
         # Save some examples in a folder. Wav files and metrics as text.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ setup(
                       'soundfile',
                       'scipy',
                       'torch',
-                      'pytorch-lightning'],
+                      'pytorch-lightning',
+                      'pb_bss@git+https://github.com/mpariente/pb_bss',
+                      ],
     extras_require={
         'visualize': ['seaborn>=0.9.0'],
         'tests': ['pytest']

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -12,8 +12,13 @@ def test_get_metrics(fs):
                                metrics_list='all')
     # Test no average & squeezing
     metrics_dict_bis = get_metrics(mix[0], clean, est, sample_rate=fs,
-                                   metrics_list='all', average=False)
-    assert float(np.mean(metrics_dict_bis['pesq'])) == metrics_dict["pesq"]
-    assert float(np.mean(metrics_dict_bis['sdr'])) == metrics_dict["sdr"]
-    assert float(np.mean(metrics_dict_bis['pesq'])) == metrics_dict["pesq"]
-    assert float(np.mean(metrics_dict_bis['pesq'])) == metrics_dict["pesq"]
+                                   metrics_list='si_sdr', average=False)
+    assert float(np.mean(metrics_dict_bis['si_sdr'])) == metrics_dict['si_sdr']
+
+
+def test_get_metrics_multichannel():
+    mix = np.random.randn(2, 16000)
+    clean = np.random.randn(2, 16000)
+    est = np.random.randn(2, 16000)
+    metrics_dict_bis = get_metrics(mix, clean, est, sample_rate=8000,
+                               metrics_list='si_sdr', average=False)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+from asteroid.metrics import get_metrics
+
+
+@pytest.mark.parametrize("fs", [8000, 16000])
+def test_get_metrics(fs):
+    mix = np.random.randn(1, 16000)
+    clean = np.random.randn(2, 16000)
+    est = np.random.randn(2, 16000)
+    metrics_dict = get_metrics(mix, clean, est, sample_rate=fs,
+                               metrics_list='all')
+    # Test no average & squeezing
+    metrics_dict_bis = get_metrics(mix[0], clean, est, sample_rate=fs,
+                                   metrics_list='all', average=False)
+    assert float(np.mean(metrics_dict_bis['pesq'])) == metrics_dict["pesq"]
+    assert float(np.mean(metrics_dict_bis['sdr'])) == metrics_dict["sdr"]
+    assert float(np.mean(metrics_dict_bis['pesq'])) == metrics_dict["pesq"]
+    assert float(np.mean(metrics_dict_bis['pesq'])) == metrics_dict["pesq"]


### PR DESCRIPTION
The goal would be to "normalize" metrics logging on Asteroid. If the same format is shared accross datasets and recipes, it is easier. 
The function works for both single and multi-source mixtures/estimate. 

#### To be done : 
Reuse the function in the recipes, where it can be used.