### PR TITLE
Downgrade to pl0.6.0

### DIFF
--- a/asteroid/engine/system.py
+++ b/asteroid/engine/system.py
@@ -114,7 +114,7 @@ class System(pl.LightningModule):
         loss = self.common_step(batch, batch_nb)
         return {'val_loss': loss}
 
-    def validation_epoch_end(self, outputs):
+    def validation_end(self, outputs):
         """ How to aggregate outputs of `validation_step` for logging.
 
         Args:
@@ -150,11 +150,18 @@ class System(pl.LightningModule):
             return [self.optimizer], [self.scheduler]
         return self.optimizer
 
+    @pl.data_loader
     def train_dataloader(self):
         return self.train_loader
 
+    @pl.data_loader
     def val_dataloader(self):
         return self.val_loader
+
+    @pl.data_loader
+    def tng_dataloader(self):  # pragma: no cover
+        """ Deprecated."""
+        pass
 
     def on_save_checkpoint(self, checkpoint):
         """ Overwrite if you want to save more things in the checkpoint."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pandas>=0.23.4
 scipy>=1.1.0
 SoundFile>=0.10.2
 torch>=1.3.0
-pytorch-lightning>=0.7.1
+pytorch-lightning==0.6.0
 pb_bss @ git+https://github.com/mpariente/pb_bss

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
                       'soundfile',
                       'scipy',
                       'torch',
-                      'pytorch-lightning',
+                      'pytorch-lightning==0.6.0',
                       'pb_bss@git+https://github.com/mpariente/pb_bss',
                       ],
     extras_require={


### PR DESCRIPTION
Everyhting in the title. 
We loose between 2 and 3dB performance on DPRNN training with the new version of pytorch-lightning. 

We'll get back to 0.7.x when the problem is fixed. 
Opened an issue [here](https://github.com/PyTorchLightning/pytorch-lightning/issues/1136) to tell them.