### PR TITLE
Speedup testing time

### DIFF
--- a/tests/filterbanks/filterbanks_test.py
+++ b/tests/filterbanks/filterbanks_test.py
@@ -12,12 +12,10 @@ from asteroid.filterbanks import make_enc_dec
 def fb_config_list():
     keys = ['n_filters', 'kernel_size', 'stride']
     param_list = [
-        [512, 256, 128],
-        [512, 256, 64],
-        [512, 32, 16],
+        [256, 256, 128],
+        [256, 256, 64],
         [500, 16, 8],
-        [200, 80, 80],
-        [200, 80, 20],
+        [200, 80, None],
     ]
     return [dict(zip(keys, values)) for values in param_list]
 
@@ -30,7 +28,7 @@ def test_fb_def_and_forward_lowdim(fb_class, fb_config):
     enc = Encoder(fb_class(**fb_config))
     dec = Decoder(fb_class(**fb_config))
     # Forward
-    inp = torch.randn(1, 1, 32000)
+    inp = torch.randn(1, 1, 16000)
     tf_out = enc(inp)
     # Assert for 2D inputs
     with pytest.warns(UserWarning):

--- a/tests/filterbanks/transforms_test.py
+++ b/tests/filterbanks/transforms_test.py
@@ -19,14 +19,10 @@ COMPLEX_FBS = [
 def fb_config_list():
     keys = ['n_filters', 'kernel_size', 'stride']
     param_list = [
-        [512, 256, 128],
-        [512, 256, 64],
-        [512, 32, 16],
+        [256, 256, 128],
+        [256, 256, 64],
+        [512, 32, None],
         [512, 16, 8],
-        [512, 257, 64],
-        [512, 80, 40],
-        [513, 80, 40],
-        [514, 80, 40]
     ]
     return [dict(zip(keys, values)) for values in param_list]
 
@@ -49,7 +45,7 @@ def make_encoder_from(fb_class, config):
 def test_mag_mask(encoder_list):
     """ Assert identity mask works. """
     for (enc, fb_dim) in encoder_list:
-        tf_rep = enc(torch.randn(2, 1, 16000))  # [batch, freq, time]
+        tf_rep = enc(torch.randn(2, 1, 8000))  # [batch, freq, time]
         id_mag_mask = torch.ones((1, fb_dim//2, 1))
         masked = transforms.apply_mag_mask(tf_rep, id_mag_mask, dim=1)
         assert_allclose(masked, tf_rep)
@@ -58,7 +54,7 @@ def test_mag_mask(encoder_list):
 def test_reim_mask(encoder_list):
     """ Assert identity mask works. """
     for (enc, fb_dim) in encoder_list:
-        tf_rep = enc(torch.randn(2, 1, 16000))  # [batch, freq, time]
+        tf_rep = enc(torch.randn(2, 1, 8000))  # [batch, freq, time]
         id_reim_mask = torch.ones((1, fb_dim, 1))
         masked = transforms.apply_real_mask(tf_rep, id_reim_mask, dim=1)
         assert_allclose(masked, tf_rep)
@@ -67,7 +63,7 @@ def test_reim_mask(encoder_list):
 def test_comp_mask(encoder_list):
     """ Assert identity mask works. """
     for (enc, fb_dim) in encoder_list:
-        tf_rep = enc(torch.randn(2, 1, 16000))  # [batch, freq, time]
+        tf_rep = enc(torch.randn(2, 1, 8000))  # [batch, freq, time]
         id_complex_mask = torch.cat((torch.ones((1, fb_dim // 2, 1)),
                                      torch.zeros((1, fb_dim // 2, 1))),
                                     dim=1)

--- a/tests/losses/pit_wrapper_test.py
+++ b/tests/losses/pit_wrapper_test.py
@@ -24,9 +24,9 @@ def good_pairwise_loss_func(y_pred, y_true):
     return torch.randn(batch, n_src, n_src)
 
 
-@pytest.mark.parametrize("batch_size", [1, 2, 8, 16])
+@pytest.mark.parametrize("batch_size", [1, 2, 8])
 @pytest.mark.parametrize("n_src", [2, 3, 4])
-@pytest.mark.parametrize("time", [16000, 32000, 1221])
+@pytest.mark.parametrize("time", [16000, 1221])
 def test_wrapper(batch_size, n_src, time):
     targets = torch.randn(batch_size, n_src, time)
     est_targets = torch.randn(batch_size, n_src, time)

--- a/tests/masknn/blocks_test.py
+++ b/tests/masknn/blocks_test.py
@@ -36,8 +36,9 @@ def test_dprnn(mask_act, out_chan, hop_size):
     
 @pytest.mark.parametrize("embed_dim", [10, 20, 30])
 def test_chimerapp(embed_dim):
-    in_chan, n_src = 512, 2
-    model = blocks.ChimeraPP(in_chan, n_src, embedding_dim=embed_dim)
+    in_chan, n_src = 52, 2
+    model = blocks.ChimeraPP(in_chan, n_src, embedding_dim=embed_dim,
+                             hidden_size=50)
     batch, freq_dim, nframes = 10, in_chan, 10
     inp = torch.randn(batch, in_chan, nframes)
     out = model(inp)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -9,11 +9,22 @@ def test_get_metrics(fs):
     clean = np.random.randn(2, 16000)
     est = np.random.randn(2, 16000)
     metrics_dict = get_metrics(mix, clean, est, sample_rate=fs,
-                               metrics_list='all')
+                               metrics_list='si_sdr')
     # Test no average & squeezing
     metrics_dict_bis = get_metrics(mix[0], clean, est, sample_rate=fs,
                                    metrics_list='si_sdr', average=False)
     assert float(np.mean(metrics_dict_bis['si_sdr'])) == metrics_dict['si_sdr']
+    assert (float(np.mean(metrics_dict_bis['input_si_sdr'])) ==
+            metrics_dict['input_si_sdr'])
+
+
+def test_all_metrics():
+    # This is separated because very slow (sdr, pesq, stoi)
+    mix = np.random.randn(1, 4000)
+    clean = np.random.randn(1, 4000)
+    est = np.random.randn(1, 4000)
+    metrics_dict = get_metrics(mix, clean, est, sample_rate=8000,
+                               metrics_list='all')
 
 
 def test_get_metrics_multichannel():


### PR DESCRIPTION
Reduce some dimensions for input tensors, specially in the slowest tests (use `--durations=N` to see the slowest N tests). 