### PR TITLE
Use pb_bss_eval on PyPI now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ python:
 # have an effect only in the build n+2.
 install:
     - for package in $NO_CACHE; do pip uninstall -y ${package}; done
-    - pip install Cython
+    - pip install numpy Cython
     - pip install pytest coverage codecov
-    - pip install pb_bss@git+https://github.com/mpariente/pb_bss
+#    - pip install pb_bss@git+https://github.com/mpariente/pb_bss
     - pip install -r requirements.txt
     - pip install -r docs/requirements.txt
     - pip install -e . --no-deps

--- a/asteroid/metrics.py
+++ b/asteroid/metrics.py
@@ -1,5 +1,5 @@
 from .utils import average_arrays_in_dic
-from pb_bss.evaluation import InputMetrics, OutputMetrics
+from pb_bss_eval import InputMetrics, OutputMetrics
 ALL_METRICS = ['si_sdr', 'sdr', 'sir', 'sar', 'stoi', 'pesq']
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ scipy>=1.1.0
 SoundFile>=0.10.2
 torch>=1.3.0
 pytorch-lightning==0.6.0
-pb_bss @ git+https://github.com/mpariente/pb_bss
+pb_bss_eval >= 0.0.1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 asteroid_version = "0.1.1"
 
@@ -22,12 +22,13 @@ setup(
                       'scipy',
                       'torch',
                       'pytorch-lightning==0.6.0',
-                      'pb_bss@git+https://github.com/mpariente/pb_bss',
+                      'pb_bss_eval',
                       ],
     extras_require={
         'visualize': ['seaborn>=0.9.0'],
         'tests': ['pytest']
     },
+    packages=find_packages(),
     classifiers=[
         'Development Status :: 4 - Beta',
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Release 0.1.1 actually won't work on PyPI because of the dependency on `pb_bss` which is not on PyPI. 

I uploaded `pb_bss_eval`, the evaluation part of `pb_bss` which can be seen on (my fork)[https://github.com/mpariente/pb_bss].
Thanks to this, the next release should work now. 