### PR TITLE
Added mixture consistency constraints

### DIFF
--- a/asteroid/masknn/consistency.py
+++ b/asteroid/masknn/consistency.py
@@ -1,0 +1,57 @@
+import torch
+
+
+def mixture_consistency(mixture, est_sources, src_weights=None, dim=1):
+    """ Applies mixture consistency to a tensor of estimated sources.
+
+    Args
+        mixture (torch.Tensor): Mixture waveform or TF representation.
+        est_sources (torch.Tensor): Estimated sources waveforms or TF
+            representations.
+        src_weights (torch.Tensor): Consistency weight for each source.
+            Shape needs to be broadcastable to `est_source`.
+            We make sure that the weights sum up to 1 along dim `dim`.
+        dim (int): Axis which contains the sources in `est_sources`.
+
+    Returns
+        torch.Tensor with same shape as `est_sources`, after applying mixture
+        consistency.
+
+    Notes
+        This method can be used only in 'complete' separation tasks, otherwise
+        the residual error will contain unwanted sources. For example, this
+        won't work with the task `sep_noisy` from WHAM.
+
+    Examples
+        >>> # Works on waveforms
+        >>> mix = torch.randn(10, 16000)
+        >>> est_sources = torch.randn(10, 2, 16000)
+        >>> new_est_sources = mixture_consistency(mix, est_sources, dim=1)
+        >>> # Also works on spectrograms
+        >>> mix = torch.randn(10, 514, 400)
+        >>> est_sources = torch.randn(10, 2, 514, 400)
+        >>> new_est_sources = mixture_consistency(mix, est_sources, dim=1)
+    """
+    # If the source weights are not specified, the weights are the relative
+    # power of each source to the sum. w_i = P_i / (P_all), P for power.
+    if src_weights is None:
+        all_dims = list(range(est_sources.ndim))
+        all_dims.pop(dim)  # Remove source axis
+        all_dims.pop(0)  # Remove batch dim
+        src_weights = torch.mean(est_sources**2, dim=all_dims, keepdim=True)
+    # Make sure that the weights sum up to 1
+    src_weights = src_weights / torch.sum(src_weights, dim=dim, keepdim=True)
+
+    # Compute residual mix - sum(est_sources)
+    if mixture.ndim == est_sources.ndim - 1:
+        residual = (mixture - est_sources.sum(dim=dim)).unsqueeze(dim)
+    elif mixture.ndim == est_sources.ndim:
+        residual = mixture - est_sources.sum(dim=dim, keepdim=True)
+    else:
+        n, m = est_sources.ndim, mixture.ndim
+        raise RuntimeError(f'The size of the mixture tensor should match the '
+                           f'size of the est_sources tensor. Expected mixture'
+                           f'tensor to have {n} or {n-1} dimension, found {m}.')
+    # Compute remove
+    new_sources = est_sources + src_weights * residual
+    return new_sources

--- a/asteroid/masknn/consistency.py
+++ b/asteroid/masknn/consistency.py
@@ -11,6 +11,7 @@ def mixture_consistency(mixture, est_sources, src_weights=None, dim=1):
         src_weights (torch.Tensor): Consistency weight for each source.
             Shape needs to be broadcastable to `est_source`.
             We make sure that the weights sum up to 1 along dim `dim`.
+            If `src_weights` is None, compute them based on relative power.
         dim (int): Axis which contains the sources in `est_sources`.
 
     Returns
@@ -31,6 +32,11 @@ def mixture_consistency(mixture, est_sources, src_weights=None, dim=1):
         >>> mix = torch.randn(10, 514, 400)
         >>> est_sources = torch.randn(10, 2, 514, 400)
         >>> new_est_sources = mixture_consistency(mix, est_sources, dim=1)
+
+    References
+        Scott Wisdom, John R Hershey, Kevin Wilson, Jeremy Thorpe, Michael
+        Chinen, Brian Patton, and Rif A Saurous. "Differentiable consistency
+        constraints for improved deep speech enhancement", ICASSP 2019.
     """
     # If the source weights are not specified, the weights are the relative
     # power of each source to the sum. w_i = P_i / (P_all), P for power.

--- a/tests/masknn/consistency_test.py
+++ b/tests/masknn/consistency_test.py
@@ -1,0 +1,42 @@
+import torch
+from torch.testing import assert_allclose
+import pytest
+
+from asteroid.masknn.consistency import mixture_consistency
+
+
+@pytest.mark.parametrize("mix_shape", [[2, 1600], [2, 130, 10]])
+@pytest.mark.parametrize("dim", [1, 2])
+@pytest.mark.parametrize("n_src", [1, 2, 3])
+def test_consistency_noweight(mix_shape, dim, n_src):
+    mix = torch.randn(mix_shape)
+    est_shape = mix_shape[:dim] + [n_src] + mix_shape[dim:]
+    est_sources = torch.randn(est_shape)
+    consistent_est_sources = mixture_consistency(mix, est_sources, dim=dim)
+    assert_allclose(mix, consistent_est_sources.sum(dim))
+
+
+@pytest.mark.parametrize("mix_shape", [[2, 1600], [2, 130, 10]])
+@pytest.mark.parametrize("dim", [1, 2])
+@pytest.mark.parametrize("n_src", [1, 2, 3])
+def test_consistency_withweight(mix_shape, dim, n_src):
+    mix = torch.randn(mix_shape)
+    est_shape = mix_shape[:dim] + [n_src] + mix_shape[dim:]
+    est_sources = torch.randn(est_shape)
+    # Create source weights : should have the same number of dims as
+    # est_sources with ones out of batch and n_src dims.
+    ones = [1 for _ in range(len(mix_shape) - 1)]
+    src_weights_shape = mix_shape[:1] + ones[:dim-1] + [n_src] + ones[dim-1:]
+    src_weights = torch.softmax(torch.randn(src_weights_shape), dim=dim)
+    # Apply mixture consitency
+    consistent_est_sources = mixture_consistency(mix, est_sources,
+                                                 src_weights=src_weights,
+                                                 dim=dim)
+    assert_allclose(mix, consistent_est_sources.sum(dim))
+
+
+def test_consistency_raise():
+    mix = torch.randn(10, 1, 1, 160)
+    est = torch.randn(10, 2, 160)
+    with pytest.raises(RuntimeError):
+        mixture_consistency(mix, est, dim=1)


### PR DESCRIPTION
Simple mixture consistency constraints that works for waveforms and spectrograms (and anything actually). 
If consistency weights are not specified, they are computed based on relative power so that silent sources do get residual as well. 
Corresponds to 3.2.2 of [this paper](https://arxiv.org/abs/1811.08521)