### PR TITLE
Add support for STOI loss

### DIFF
--- a/asteroid/losses/__init__.py
+++ b/asteroid/losses/__init__.py
@@ -5,6 +5,7 @@ from .sdr import singlesrc_neg_snr, multisrc_neg_snr
 from .mse import singlesrc_mse, multisrc_mse
 from .cluster import deep_clustering_loss
 from .pmsqe import SingleSrcPMSQE
+from .stoi import NegSTOILoss as SingleSrcNegSTOI
 
 # Legacy
 from .sdr import pairwise_neg_sisdr, nosrc_neg_sisdr, nonpit_neg_sisdr

--- a/asteroid/losses/stoi.py
+++ b/asteroid/losses/stoi.py
@@ -1,0 +1,13 @@
+from torch_stoi import NegSTOILoss
+
+asteroid_examples = """
+Examples:
+    >>> import torch
+    >>> from asteroid.losses import PITLossWrapper
+    >>> targets = torch.randn(10, 2, 32000)
+    >>> est_targets = torch.randn(10, 2, 32000)
+    >>> loss_func = PITLossWrapper(NegSTOILoss(), pit_from='pw_pt')
+    >>> loss = loss_func(est_targets, targets)
+"""
+
+NegSTOILoss.__doc__ += asteroid_examples

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ torch>=1.3.0
 pytorch-lightning==0.6.0
 pb_bss_eval>=0.0.1
 asranger>=0.0.5
+torch_stoi>=0.0.1

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
                       'pytorch-lightning==0.6.0',
                       'pb_bss_eval',
                       'asranger',
+                      'torch_stoi',
                       ],
     extras_require={
         'visualize': ['seaborn>=0.9.0'],

--- a/tests/losses/loss_functions_test.py
+++ b/tests/losses/loss_functions_test.py
@@ -7,7 +7,9 @@ from asteroid.losses import PITLossWrapper
 from asteroid.losses import sdr
 from asteroid.losses import singlesrc_mse, pairwise_mse, multisrc_mse
 from asteroid.losses import deep_clustering_loss, SingleSrcPMSQE
+from asteroid.losses import SingleSrcNegSTOI
 from asteroid.losses.multi_scale_spectral import SingleSrcMultiScaleSpectral
+
 
 @pytest.mark.parametrize("n_src", [2, 3, 4])
 @pytest.mark.parametrize("function_triplet", [
@@ -116,4 +118,18 @@ def test_pmsqe_pit(n_src, sample_rate):
     loss_func = PITLossWrapper(SingleSrcPMSQE(sample_rate=sample_rate),
                                pit_from='pw_pt')
     # Assert forward ok.
-    loss_value = loss_func(ref_spec, est_spec)
+    loss_value = loss_func(est_spec, ref_spec)
+
+
+@pytest.mark.parametrize("n_src", [2, 3])
+@pytest.mark.parametrize("sample_rate", [8000, 16000])
+@pytest.mark.parametrize("use_vad", [True, False])
+@pytest.mark.parametrize("extended", [True, False])
+def test_negstoi_pit(n_src, sample_rate, use_vad, extended):
+    ref, est = torch.randn(2, n_src, 16000), torch.randn(2, n_src, 16000)
+    singlesrc_negstoi = SingleSrcNegSTOI(sample_rate=sample_rate,
+                                         use_vad=use_vad,
+                                         extended=extended)
+    loss_func = PITLossWrapper(singlesrc_negstoi, pit_from='pw_pt')
+    # Assert forward ok.
+    loss_value = loss_func(est, ref)


### PR DESCRIPTION
I finally implemented the STOI loss with some minor modifications. 
Implementation can be found [here](https://github.com/mpariente/pytorch_stoi).

I just wrapped the class in Asteroid and added an example to the docstring (we might want to insert it before the reference section, I'll see when I have time for that). 

Also, this is not yet suitable for non-PIT applications with a source axis because 
`(batch, n_src, dim2, time) --> (batch, n_src, dim2)`, we just need to take an average and I'll probably do it here rather than there.
