### PR TITLE
No skip option to TDCN

### DIFF
--- a/asteroid/masknn/blocks.py
+++ b/asteroid/masknn/blocks.py
@@ -14,6 +14,9 @@ class Conv1DBlock(nn.Module):
         hid_chan (int): Number of hidden channels in the depth-wise
             convolution.
         skip_out_chan (int): Number of channels in the skip convolution.
+            If 0 or None, `Conv1DBlock` won't have any skip connections.
+            Corresponds to the the block in v1 or the paper. The `forward`
+            return [res, res] instead of [res, skip] for consistency.
         kernel_size (int): Size of the depth-wise convolutional kernel.
         padding (int): Padding of the depth-wise convolution.
         dilation (int): Dilation of the depth-wise convolution.
@@ -31,6 +34,7 @@ class Conv1DBlock(nn.Module):
     def __init__(self, in_chan, hid_chan, skip_out_chan, kernel_size, padding,
                  dilation, norm_type="gLN"):
         super(Conv1DBlock, self).__init__()
+        self.skip_out_chan = skip_out_chan
         conv_norm = norms.get(norm_type)
         in_conv1d = nn.Conv1d(in_chan, hid_chan, 1)
         depth_conv1d = nn.Conv1d(hid_chan, hid_chan, kernel_size,
@@ -40,12 +44,16 @@ class Conv1DBlock(nn.Module):
                                           conv_norm(hid_chan), depth_conv1d,
                                           nn.PReLU(), conv_norm(hid_chan))
         self.res_conv = nn.Conv1d(hid_chan, in_chan, 1)
-        self.skip_conv = nn.Conv1d(hid_chan, skip_out_chan, 1)
+        if skip_out_chan:
+            self.skip_conv = nn.Conv1d(hid_chan, skip_out_chan, 1)
 
     def forward(self, x):
         """ Input shape [batch, feats, seq]"""
         shared_out = self.shared_block(x)
         res_out = self.res_conv(shared_out)
+        if not self.skip_out_chan:
+            # Return it twice to have consistent number of outputs
+            return res_out, res_out
         skip_out = self.skip_conv(shared_out)
         return res_out, skip_out
 
@@ -65,10 +73,18 @@ class TDConvNet(nn.Module):
         hid_chan (int, optional): Number of channels in the convolutional
             blocks.
         skip_chan (int, optional): Number of channels in the skip connections.
+            If 0 or None, TDConvNet won't have any skip connections and the
+            masks will be computed from the residual output.
+            Corresponds to the ConvTasnet architecture in v1 or the paper.
         kernel_size (int, optional): Kernel size in convolutional blocks.
         norm_type (str, optional): To choose from ``'BN'``, ``'gLN'``,
             ``'cLN'``.
         mask_act (str, optional): Which non-linear function to generate mask.
+
+    References:
+        [1] : "Conv-TasNet: Surpassing ideal time-frequency magnitude masking
+        for speech separation" TASLP 2019 Yi Luo, Nima Mesgarani
+        https://arxiv.org/abs/1809.07454
     """
     def __init__(self, in_chan, n_src, out_chan=None, n_blocks=8, n_repeats=3,
                  bn_chan=128, hid_chan=512, skip_chan=128, kernel_size=3,
@@ -98,7 +114,8 @@ class TDConvNet(nn.Module):
                 self.TCN.append(Conv1DBlock(bn_chan, hid_chan, skip_chan,
                                             kernel_size, padding=padding,
                                             dilation=2**x, norm_type=norm_type))
-        mask_conv = nn.Conv1d(skip_chan, n_src*out_chan, 1)
+        mask_conv_inp = skip_chan if skip_chan else bn_chan
+        mask_conv = nn.Conv1d(mask_conv_inp, n_src*out_chan, 1)
         self.mask_net = nn.Sequential(nn.PReLU(), mask_conv)
         # Get activation function.
         mask_nl_class = activations.get(mask_act)
@@ -123,10 +140,15 @@ class TDConvNet(nn.Module):
         output = self.bottleneck(mixture_w)
         skip_connection = 0.
         for i in range(len(self.TCN)):
+            # Common to w. skip and w.o skip architectures
             residual, skip = self.TCN[i](output)
             output = output + residual
-            skip_connection = skip_connection + skip
-        score = self.mask_net(skip_connection)
+            # Only if skip connections
+            if self.skip_chan:
+                skip_connection = skip_connection + skip
+        # Use residual output when no skip connection
+        mask_inp = skip_connection if self.skip_chan else output
+        score = self.mask_net(mask_inp)
         score = score.view(batch, self.n_src, self.out_chan, n_frames)
         est_mask = self.output_act(score)
         return est_mask

--- a/tests/masknn/blocks_test.py
+++ b/tests/masknn/blocks_test.py
@@ -5,11 +5,12 @@ from asteroid.masknn import blocks
 
 @pytest.mark.parametrize("mask_act", ["relu", "softmax"])
 @pytest.mark.parametrize("out_chan", [None, 10])
-def test_tdconvnet(mask_act, out_chan):
+@pytest.mark.parametrize("skip_chan", [0, 12])
+def test_tdconvnet(mask_act, out_chan, skip_chan):
     in_chan, n_src = 20, 2
     model = blocks.TDConvNet(in_chan=in_chan, n_src=n_src, mask_act=mask_act,
                              n_blocks=2, n_repeats=2, bn_chan=10, hid_chan=11,
-                             skip_chan=12, out_chan=out_chan)
+                             skip_chan=skip_chan, out_chan=out_chan)
     batch, n_frames = 2, 24
     inp = torch.randn(batch, in_chan, n_frames)
     out = model(inp)


### PR DESCRIPTION
This adds the possibility to make the same architecture as the v1 of the ConvTasnet paper, without skip connections. 

In particular, @etzinis used this version, can you confirm? 