### PR TITLE
Deep clustering updates

### DIFF
--- a/asteroid/data/wav.py
+++ b/asteroid/data/wav.py
@@ -95,10 +95,11 @@ class SingleWav(object):
         if duration == -1:
             return self.data
         self.update_info()
-        assert duration < self.info.duration,\
+        assert duration <= self.info.duration,\
                 'Requested duration exceeds signal length'
         max_sample = int((self.info.duration - duration) * self.sampling_rate)
-        start_sample = np.random.randint(0,max_sample)
+        start_sample = np.random.randint(0,max_sample) if \
+                max_sample > 0 else 0
         end_sample = start_sample + int(duration * self.sampling_rate)
         return self.part_data(start_sample, end_sample)
 

--- a/asteroid/data/wsj0_mix.py
+++ b/asteroid/data/wsj0_mix.py
@@ -1,13 +1,68 @@
 import torch
 from torch.utils import data
+from torch.utils.data.sampler import Sampler
 import json
 import os
 import numpy as np
 import soundfile as sf
+from glob import glob
+
 from asteroid.data.wav import SingleWav
 from asteroid.filterbanks.transforms import take_mag
 
 EPS = torch.finfo(torch.float).eps
+
+def collate_fn(batch):
+    """ Trim all elements of the batch to ensure they have the same 
+    length
+    """
+    batch = sorted(batch, key=lambda sample: sample[0].shape[0],
+            reverse=True)
+    smallest_sample = batch[-1]
+    minibatch_size = len(batch)
+    src_cnt = smallest_sample[1].shape[0]
+    sample_len = smallest_sample[0].shape[0]
+
+    mixture = torch.zeros(minibatch_size, sample_len)
+    sources = torch.zeros(minibatch_size, src_cnt, sample_len)
+
+    for sample_idx in range(minibatch_size):
+        sample = batch[sample_idx]
+        mixture[sample_idx] = sample[0][:sample_len]
+        sources[sample_idx] = sample[1][...,:sample_len]
+    return mixture, sources
+
+
+
+class BucketingSampler(Sampler):
+    def __init__(self, data_source, batch_size=1, percentage=1):
+        """
+        Samples batches assuming they are in order of size to batch similarly sized samples together.
+        Taken from deepspeech github codebase in data/data_loader.py
+        percentage: Amount of data to take
+        """
+        Sampler.__init__(self, data_source)
+        self.data_source = data_source
+        print('At BucketingSampler: Available ', data_source.len)
+        to_take = int(percentage * data_source.len)
+        print('At BucketingSampler: Samples to take', to_take)
+        assert to_take > batch_size, 'Number of samples should atleast be greater than batch_size'
+        ids = list(range(0, to_take))
+        self.bins = [ids[i:i + batch_size] for i in range(0, len(ids), batch_size)]
+        self.shuffle(0)
+
+    def __iter__(self):
+        self.shuffle(0)
+        for ids in self.bins:
+            np.random.shuffle(ids)
+            yield ids
+
+    def __len__(self):
+        return len(self.bins)
+
+    def shuffle(self, epoch):
+        print('shuffling bins')
+        np.random.shuffle(self.bins)
 
 class WSJmixDataset(data.Dataset):
     """
@@ -26,7 +81,7 @@ class WSJmixDataset(data.Dataset):
     def __init__(self, wav_len_list, wav_base_path, callback_func=None,
             elements=['mix', 's1', 's2'], sample_rate=8000, segment=None):
         segment_samples = segment * sample_rate if segment is not None else -1
-        self.segment = segment if segment is not None else -1
+        self.segment = float(segment) if segment is not None else -1
         assert os.path.exists(wav_len_list), wav_len_list+' does not exists'
         data.Dataset.__init__(self)
         id_list = []
@@ -53,7 +108,7 @@ class WSJmixDataset(data.Dataset):
         # Create an identity function if callback is None
         self.callback_func = callback_func if callback_func is not None \
                 else self.identity
-        print("{}% file dropped".format(100*(1-self.len/len(id_list))))
+        print("{:f}% file dropped".format(100*(1-self.len/len(id_list))))
 
     def identity(self, *kargs):
         return kargs
@@ -90,14 +145,16 @@ class WSJ2mixDataset(WSJmixDataset):
 
     def __getitem__(self, idx):
         item_id = self.id_list[idx]
-        mixture = self.id_wav_map[item_id]["mix"].\
-                    random_part_data(self.segment).T[0]
+        try:
+            mixture = self.id_wav_map[item_id]["mix"].data.T[0]
+        except:
+            print(self.id_wav_map[item_id]["mix"].file_name)
+            exit(0)
         source_arrays = []
         for _src_ in self.sources:
-            source_arrays.append(self.id_wav_map[item_id][_src_].\
-                    random_part_data(self.segment).T[0])
-        sources = torch.from_numpy(np.vstack(source_arrays))
-        mixture = torch.from_numpy(mixture)
+            source_arrays.append(self.id_wav_map[item_id][_src_].data.T[0])
+        sources = torch.from_numpy(np.vstack(source_arrays)).type(torch.float32)
+        mixture = torch.from_numpy(mixture).type(torch.float32)
         return self.callback_func(mixture, sources) 
 
 
@@ -121,6 +178,26 @@ class WSJ3mixDataset(WSJ2mixDataset):
                 elements=['mix'] + sources, sample_rate=sample_rate, \
                 segment=segment)
         self.sources = sources
+
+
+def create_wav_id_sample_count_list(base_path, dest):
+    """ Create a list file with the following entry per line
+        wav_id sample_count
+    Args:
+        base_path: str. Path to either mix, s1 or s2 directory
+        dest: str. Path to save the list file
+    """
+    all_wav_files = glob(os.path.join(base_path, '*.wav'))
+    wid = open(dest, 'w')
+    id_sample_array = []
+    for _file in all_wav_files:
+        sample_cnt = sf.info(_file).frames
+        wav_id = os.path.basename(_file)
+        id_sample_array.append((wav_id, sample_cnt))
+    id_sample_array = sorted(id_sample_array, key=lambda x: x[1])
+    for wav_id, sample_cnt in id_sample_array:
+        wid.write('{}\t{}\n'.format(wav_id, sample_cnt))
+    wid.close()
 
 
 def transform(mixture, sources):

--- a/asteroid/masknn/blocks.py
+++ b/asteroid/masknn/blocks.py
@@ -433,7 +433,7 @@ class ChimeraPP(nn.Module):
     """
     def __init__(self, in_chan, n_src, rnn_type = 'lstm',
             embedding_dim=20, n_layers=2, hidden_size=600,
-            dropout=0, bidirectional=True):
+            dropout=0, bidirectional=True, log=False):
         super(ChimeraPP, self).__init__()
         self.input_dim = in_chan
         self.n_src = n_src
@@ -446,9 +446,17 @@ class ChimeraPP(nn.Module):
                 in_chan * embedding_dim)
         self.mask_layer = nn.Linear(rnn_out_dim, in_chan * n_src)
         self.non_linearity = nn.Sigmoid()
+        self.log = log
+        self.EPS = torch.finfo(torch.float32).eps
+        if log:
+            #TODO: Use pytorch lightning logger here
+            print('Using log spectrum as input')
+
 
     def forward(self, input_data):
         batches, freq_dim, seq_cnt = input_data.shape
+        if self.log:
+            input_data = torch.log(input_data + self.EPS)
         out = self.rnn(input_data.permute(0,2,1))
         out = self.dropout(out)
         projection = self.embedding_layer(out)
@@ -458,5 +466,8 @@ class ChimeraPP(nn.Module):
                 torch.finfo(torch.float32).eps
         projection_final =  projection/proj_norm
         mask_out = self.mask_layer(out)
-        mask_out = mask_out.view(batches, self.n_src, self.input_dim, seq_cnt)
+        #mask_out = mask_out.view(batches, self.n_src, self.input_dim, seq_cnt)
+        mask_out = mask_out.view(batches, seq_cnt, self.n_src,
+                self.input_dim).permute(0, 2, 3, 1) 
+        mask_out = self.non_linearity(mask_out)
         return projection_final, mask_out

--- a/egs/wsj0-mix/DeepClustering/eval.py
+++ b/egs/wsj0-mix/DeepClustering/eval.py
@@ -1,0 +1,110 @@
+''' Evaluation of the Deep clustering model '''
+import os
+import argparse
+import random
+import sklearn
+import torch
+import tqdm
+from torch.utils.data import DataLoader
+
+from asteroid.losses import PITLossWrapper, pairwise_neg_sisdr, pairwise_mse
+from asteroid.data.wsj0_mix import WSJ2mixDataset 
+#from asteroid.metrics import get_metrics
+import asteroid.filterbanks as fb
+from asteroid.filterbanks.transforms import take_mag
+from model import load_best_model
+from train import DcSystem
+
+from ipdb import set_trace
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--use_gpu', type=int, default=0,
+                    help='Whether to use the GPU for model execution')
+parser.add_argument('--exp_dir', default='exp/tmp',
+                    help='Experiment root')
+parser.add_argument('--n_save_ex', type=int, default=-1,
+                    help='Number of audio examples to save, -1 means all')
+compute_metrics = ['si_sdr', 'sdr', 'sir', 'sar', 'stoi']
+
+kmeans = sklearn.cluster.KMeans(n_clusters=2)
+
+def main(conf):
+    set_trace()
+    test_set = WSJ2mixDataset(conf['data']['tt_wav_len_list'],
+                              conf['data']['wav_base_path']+'/tt',
+                              sample_rate=conf['data']['sample_rate'])
+    test_loader = DataLoader(test_set, shuffle=True,
+                             batch_size=1,
+                             num_workers=conf['data']['num_workers'],
+                             drop_last=False)
+    istft = fb.Decoder(fb.STFTFB(**conf['filterbank']))
+    exp_dir = conf['main_args']['exp_dir']
+    model_path = os.path.join(exp_dir, 'checkpoints/_ckpt_epoch_0.ckpt')
+    model = load_best_model(conf, model_path)
+    pit_loss = PITLossWrapper(pairwise_mse, mode='pairwise')
+
+    system = DcSystem(model, None, None, None, config=conf)
+
+    # Randomly choose the indexes of sentences to save.
+    exp_dir = conf['main_args']['exp_dir']
+    exp_save_dir = os.path.join(exp_dir, 'examples/')
+    n_save = conf['main_args']['n_save_ex']
+    if n_save == -1:
+        n_save = len(test_set)
+    save_idx = random.sample(range(len(test_set)), n_save)
+    series_list = []
+    torch.no_grad().__enter__()
+
+    for batch in test_loader:
+        batch = [ele.type(torch.float32) for ele in batch]
+        inputs, targets, masks = system.unpack_data(batch)
+        est_targets = system(inputs)
+        mix_stft = system.enc(inputs.unsqueeze(1))
+        min_loss, min_idx = pit_loss.best_perm_from_perm_avg_loss(\
+                pairwise_mse, est_targets[1], masks)
+        for sidx in min_idx:
+            src_stft = mix_stft * est_targets[1][sidx]
+            src_sig = istft(src_stft)
+
+
+def cluster(self, net_embed, vad_mask):
+    """
+
+    source: github.com/funcwj/deep-clustering.git
+    Arguments
+        spectra:    log-magnitude spectrogram(real numbers)
+        net_embed: Embedding output from network: Dimension TF x D
+        vad_mask:   binary mask for non-silence bins(if non-sil: 1)
+        return
+            pca_embed: PCA embedding vector(dim 3)
+            spk_masks: binary masks for each speaker
+    """
+    # filter silence embeddings: TF x D => N x D
+    active_embed = net_embed[vad_mask.reshape(-1)]
+    # classes: N x D
+    # pca_mat: N x 3
+    classes = self.kmeans.fit_predict(active_embed)
+
+    def form_mask(classes, spkid, vad_mask):
+        mask = ~vad_mask
+        # mask = np.zeros_like(vad_mask)
+        mask[vad_mask] = (classes == spkid)
+        return mask
+
+    return [
+        form_mask(classes, spk, vad_mask) for spk in range(self.num_spks)
+    ]
+
+
+
+
+if __name__ == '__main__':
+    import yaml
+    from asteroid.utils import prepare_parser_from_dict, parse_args_as_dict
+
+    with open('local/conf.yml') as f:
+        def_conf = yaml.safe_load(f)
+    parser = prepare_parser_from_dict(def_conf, parser=parser)
+    arg_dic, plain_args = parse_args_as_dict(parser, return_plain_args=True)
+    print(arg_dic)
+    main(arg_dic)

--- a/egs/wsj0-mix/DeepClustering/local/conf.yml
+++ b/egs/wsj0-mix/DeepClustering/local/conf.yml
@@ -1,8 +1,12 @@
 # Filterbank config
 filterbank:
-  n_filters: 512
-  kernel_size: 512
-  stride: 256
+# n_filters: 512
+# kernel_size: 512
+# stride: 256
+ n_filters: 256
+ kernel_size: 256
+ stride: 64
+ log: True # Use log spectra as input
 # Training config
 training:
   epochs: 100
@@ -18,13 +22,18 @@ optim:
   weight_decay: 0.
 # Data config
 data:
-  tr_wav_len_list: /srv/storage/talc3@talc-data.nancy/multispeech/calcul/users/ssivasankaran/experiments/data/speech_separation/wsj0-mix/2speakers_reverb_kinect_chime_noise_corrected/wav16k/max/tr.wavid.sample.10
-  cv_wav_len_list: /srv/storage/talc3@talc-data.nancy/multispeech/calcul/users/ssivasankaran/experiments/data/speech_separation/wsj0-mix/2speakers_reverb_kinect_chime_noise_corrected/wav16k/max/cv.wavid.sample.10
-  wav_base_path: /srv/storage/talc3@talc-data.nancy/multispeech/calcul/users/ssivasankaran/experiments/data/speech_separation/wsj0-mix/2speakers_reverb_kinect_chime_noise_corrected/wav16k/max/
+    #  tr_wav_len_list: /srv/storage/talc3@talc-data.nancy/multispeech/calcul/users/ssivasankaran/experiments/data/speech_separation/wsj0-mix/2speakers_reverb_kinect_chime_noise_corrected/wav16k/max/tr.wavid.sample
+    #  cv_wav_len_list: /srv/storage/talc3@talc-data.nancy/multispeech/calcul/users/ssivasankaran/experiments/data/speech_separation/wsj0-mix/2speakers_reverb_kinect_chime_noise_corrected/wav16k/max/cv.wavid.sample
+    #  tt_wav_len_list: /srv/storage/talc3@talc-data.nancy/multispeech/calcul/users/ssivasankaran/experiments/data/speech_separation/wsj0-mix/2speakers_reverb_kinect_chime_noise_corrected/wav16k/max/tt.wavid.sample.head
+  tr_wav_len_list: exp/tr.wavid.samples
+  cv_wav_len_list: exp/cv.wavid.samples
+  tt_wav_len_list: exp/tt.wavid.samples
+  wav_base_path: /srv/storage/talc3@talc-data.nancy/multispeech/calcul/users/ssivasankaran/experiments/data/speech_separation/wsj0-mix/2speakers/wav8k/min/
+  #wav_base_path: /tmp/min
   task: sep_clean
   nondefault_nsrc:
-  sample_rate: 16000
+  sample_rate: 8000
   mode: max
-  batch_size: 3
-  num_workers: 4
-  segment: 1 # Segment length in seconds for training
+  batch_size: 4
+  num_workers: 20
+  segment: 4 # Segment length in seconds for training

--- a/egs/wsj0-mix/DeepClustering/model.py
+++ b/egs/wsj0-mix/DeepClustering/model.py
@@ -1,5 +1,7 @@
+import os
 import torch as th
 from torch import nn
+from asteroid import torch_utils
 
 import asteroid.filterbanks as fb
 from asteroid.masknn import TDConvNet
@@ -33,8 +35,31 @@ def make_model_and_optimizer(conf):
     enc = fb.Encoder(fb.STFTFB(**conf['filterbank']))
     masker = ChimeraPP(int(enc.filterbank.n_feats_out/2), 2,
                        embedding_dim=20, n_layers=2, hidden_size=600, \
-                       dropout=0, bidirectional=True)
+                       dropout=0.5, bidirectional=True, \
+                       log=conf['filterbank']['log'])
     model = Model(enc, masker)
     optimizer = make_optimizer(model.parameters(), **conf['optim'])
     return model, optimizer
 
+def load_best_model(train_conf, best_model_path):
+    """ Load best model after training.
+
+    Args:
+        train_conf (dict): dictionary as expected by `make_model_and_optimizer`
+        exp_dir(str): Experiment directory. Expects to find
+            `'best_k_models.json'` there.
+
+    Returns:
+        nn.Module the best pretrained model according to the val_loss.
+    """
+    # Create the model from recipe-local function
+    model, _ = make_model_and_optimizer(train_conf)
+    # Last best model summary
+    checkpoint = th.load(best_model_path, map_location='cpu')
+    # Removing additional saved info 
+    checkpoint['state_dict'].pop('enc.filterbank._filters')
+    # Load state_dict into model.
+    model = torch_utils.load_state_dict_in(checkpoint['state_dict'],
+                                           model)
+    model.eval()
+    return model

--- a/egs/wsj0-mix/DeepClustering/simple_train.py
+++ b/egs/wsj0-mix/DeepClustering/simple_train.py
@@ -1,0 +1,238 @@
+import os
+import argparse
+import json
+from ipdb import set_trace
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+import torch.nn as nn
+from torch import optim
+
+from asteroid.filterbanks.transforms import take_mag
+import asteroid.filterbanks as fb
+from asteroid.data.wsj0_mix import WSJ2mixDataset, BucketingSampler, \
+        collate_fn
+from asteroid.masknn.blocks import SingleRNN
+from asteroid.losses import PITLossWrapper, pairwise_mse
+from asteroid.losses import deep_clustering_loss
+
+EPS = torch.finfo(torch.float32).eps
+enc = fb.Encoder(fb.STFTFB(256, 256, stride=64))
+enc = enc.cuda()
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--gpus', type=str, help='list of GPUs', default='-1')
+parser.add_argument('--exp_dir', default='exp/tmp',
+                    help='Full path to save best validation model')
+
+pit_loss = PITLossWrapper(pairwise_mse, mode='pairwise')
+
+class Model(nn.Module):
+    def __init__(self):
+    #def __init__(self, in_chan, n_src, rnn_type = 'lstm',
+    #        embedding_dim=20, n_layers=2, hidden_size=600,
+    #        dropout=0, bidirectional=True, log=False):
+        super(Model, self).__init__()
+        in_chan = 129
+        rnn_type = 'lstm'
+        self.input_dim = in_chan
+        n_layers = 2
+        hidden_size = 600
+        bidirectional = True
+        dropout = 0.5
+        embedding_dim = 20
+    #    self.n_src = n_src
+        self.embedding_dim = embedding_dim
+        self.rnn = SingleRNN(rnn_type, in_chan, hidden_size, n_layers, \
+            dropout, bidirectional)
+        self.dropout = nn.Dropout(dropout)
+        rnn_out_dim = hidden_size * 2 if bidirectional else hidden_size
+    #    self.embedding_layer = nn.Linear(rnn_out_dim, \
+    #            in_chan * embedding_dim)
+        self.embedding_layer = nn.Linear(rnn_out_dim, \
+                in_chan * embedding_dim)
+        self.mask_layer = nn.Linear(rnn_out_dim, in_chan * 2)
+        self.non_linearity = nn.Sigmoid()
+        self.EPS = torch.finfo(torch.float32).eps
+    #    if log:
+    #        #TODO: Use pytorch lightning logger here
+    #       print('Using log spectrum as input')
+        # Temp check
+        self.lin1 = nn.Linear(in_chan, in_chan)
+        self.lin2 = nn.Linear(in_chan, in_chan)
+
+    def forward(self, input_data):
+        batches, freq_dim, seq_cnt = input_data.shape
+        out = self.rnn(input_data.permute(0,2,1))
+        out = self.dropout(out)
+        mask_out = self.mask_layer(out)
+        mask_out = mask_out.view(batches, seq_cnt, 2,
+                self.input_dim).permute(0, 2, 3, 1) 
+        mask_out = self.non_linearity(mask_out)
+
+        projection = self.embedding_layer(out)
+        projection = self.non_linearity(projection)
+        projection = projection.view(batches, -1, self.embedding_dim)
+        proj_norm = torch.norm(projection, p=2, dim=-1, keepdim=True) + \
+                torch.finfo(torch.float32).eps
+        projection_final =  projection/proj_norm
+        #return None, mask_out[...,:self.input_dim]
+        return projection_final, mask_out
+
+class Model1(nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+        in_chan = 129
+        self.lin1 = nn.Linear(in_chan, in_chan)
+        self.lin2 = nn.Linear(in_chan, in_chan)
+        self.non_linearity = nn.Sigmoid()
+
+    def forward(self, input_data):
+        out = self.lin1(input_data.permute(0,2,1))
+        out = self.non_linearity(out)
+        out = self.lin2(out)
+        out = self.non_linearity(out)
+        return  None, out
+
+def unpack_data(batch):
+    mix, sources = batch
+    n_batch, n_src, n_sample = sources.shape
+    new_sources = sources.view(-1, n_sample).unsqueeze(1)
+    src_mag_spec = take_mag(enc(new_sources))
+    fft_dim = src_mag_spec.shape[1]
+    src_mag_spec = src_mag_spec.view(n_batch, n_src, fft_dim, -1)
+    src_sum = src_mag_spec.sum(1).unsqueeze(1) + EPS
+    real_mask = src_mag_spec/src_sum
+    # Get the src idx having the maximum energy
+    binary_mask = real_mask.argmax(1)
+    return mix, binary_mask, real_mask
+
+def compute_cost(model, batch):
+    inputs, targets, masks = unpack_data(batch)
+    spec = take_mag(enc(inputs.unsqueeze(1)))
+    #spec = take_mag(enc(batch[1][:,0,:].unsqueeze(1)))
+    spec = spec.cuda()
+    est_targets = model(spec)
+    #masks = torch.stack((masks[:,0,...], masks[:,0,...]),dim=1)
+    #masks = masks[:,0,...].permute(0,2,1)
+    #masks = masks.permute(0,2,1)
+    masks = masks.cuda()
+    #temp = torch.rand(5,129, 300)
+    #temp = temp.cuda()
+    #est_targets = model(temp)
+    #masks = temp.permute(0,2,1)
+    #torch.save((masks.data.cpu(), spec.data.cpu()), 'mask_spec.pt')
+    #loss = torch.sqrt(torch.pow(est_targets[1] - masks, 2)+EPS).mean()
+    #loss = torch.pow(est_targets[1] - masks, 2).mean()
+    #loss = pairwise_mse(est_targets[1], masks).mean()
+    loss = pit_loss(est_targets[1], masks)
+    embedding = est_targets[0]
+
+    vad_tf_mask =  compute_vad(spec).cuda()
+    targets = targets.cuda()
+    dc_loss = deep_clustering_loss(embedding, targets, 
+            binary_mask=vad_tf_mask)
+    #loss = torch.sqrt(torch.pow(est_targets[1] - spec.permute(0,2,1), 2)).mean()
+    return dc_loss, loss
+
+def compute_vad(spectra, threshold_db=40):
+    ''' Compute a time-frequency VAD
+    source: github.com/funcwj/deep-clustering.git
+    '''
+    # to dB
+    spectra_db = 20 * torch.log10(spectra)
+    max_magnitude_db = torch.max(spectra_db)
+    threshold = 10**((max_magnitude_db - threshold_db) / 20)
+    mask = spectra > threshold
+    return mask.double()
+
+def main(conf):
+    train_set = WSJ2mixDataset(conf['data']['tr_wav_len_list'],
+                               conf['data']['wav_base_path']+'/tr',
+                               sample_rate=conf['data']['sample_rate'])
+    val_set = WSJ2mixDataset(conf['data']['cv_wav_len_list'],
+                             conf['data']['wav_base_path']+'/cv',
+                             sample_rate=conf['data']['sample_rate'])
+    train_set.shuffle_list()
+    val_set.shuffle_list()
+    #train_set.id_list = train_set.id_list[:5]
+    #val_set.id_list = val_set.id_list[:5]
+    #train_set.len = 5
+    #val_set.len = 5
+
+    train_sampler = BucketingSampler(train_set,
+                                     batch_size=conf['data']['batch_size'])
+    valid_sampler = BucketingSampler(val_set,
+                                     batch_size=conf['data']['batch_size'])
+
+    train_loader = DataLoader(train_set, 
+                              batch_sampler=train_sampler,
+                              collate_fn=collate_fn,
+                              num_workers=conf['data']['num_workers'])
+    val_loader = DataLoader(val_set, 
+                            batch_sampler=valid_sampler,
+                            collate_fn=collate_fn,
+                            num_workers=conf['data']['num_workers'])
+
+    model = Model().cuda()
+    optimizer = optim.Adam(model.parameters())
+
+    for _ in range(50):
+        train_loss = 0
+        dc_loss_all = 0
+        pit_loss_all = 0
+        for batch_nb, temp_batch in enumerate(train_loader):
+            batch_nb += 1
+            batch = [el.cuda() for el in temp_batch]
+            #batch = temp_batch
+            model.train()
+            optimizer.zero_grad()
+            dc_loss, pit_loss_val = compute_cost(model, batch)
+            if np.isnan(dc_loss.item()):
+                print('\n')
+                set_trace()
+                dc_loss, pit_loss_val = compute_cost(model, batch)
+            dc_loss *= 1e-4
+            loss = dc_loss + pit_loss_val
+
+            train_loss += loss.item()
+            dc_loss_all += dc_loss.item()
+            pit_loss_all += pit_loss_val.item()
+
+            #loss.backward()
+            pit_loss_val.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 5)
+            optimizer.step()
+            print('{}\t total:{:06.4f}\t dc:{:06.4f}\t pit:{:06.4f}'.format(batch_nb, train_loss/(batch_nb), dc_loss_all/(batch_nb), pit_loss_all/batch_nb),
+                    end='\r')
+        print('Train loss {}\t total:{:06.4f}\t dc:{:06.4f}\t pit:{:06.4f}'.format(batch_nb, train_loss/(batch_nb), dc_loss_all/(batch_nb), pit_loss_all/batch_nb))
+
+        train_loss = 0
+        dc_loss_all = 0
+        pit_loss_all = 0
+        for batch_nb, temp_batch in enumerate(val_loader):
+        #for batch_nb, temp_batch in enumerate(train_loader):
+            batch = [el.cuda() for el in temp_batch]
+            #batch = temp_batch
+            model.eval()
+            dc_loss, pit_loss_val = compute_cost(model, batch)
+            loss = dc_loss + pit_loss_val
+
+            train_loss += loss.item()
+            dc_loss_all += dc_loss.item()
+            pit_loss_all += pit_loss_val.item()
+            print('{}\t total:{:06.4f}\t dc:{:06.4f}\t pit:{:06.4f}'.format(batch_nb, train_loss/(batch_nb), dc_loss_all/(batch_nb), pit_loss_all/batch_nb))
+        print('Valid loss {}\t total:{:06.4f}\t dc:{:06.4f}\t pit:{:06.4f}'.format(batch_nb, train_loss/(batch_nb), dc_loss_all/(batch_nb), pit_loss_all/batch_nb))
+
+if __name__ == '__main__':
+    import yaml
+    from asteroid.utils import prepare_parser_from_dict, parse_args_as_dict
+
+    with open('local/conf.yml') as f:
+        def_conf = yaml.safe_load(f)
+    parser = prepare_parser_from_dict(def_conf, parser=parser)
+    arg_dic, plain_args = parse_args_as_dict(parser, return_plain_args=True)
+    set_trace()
+    print(arg_dic)
+    main(arg_dic)

--- a/egs/wsj0-mix/DeepClustering/train.py
+++ b/egs/wsj0-mix/DeepClustering/train.py
@@ -2,13 +2,16 @@
 """
 import os
 import argparse
+import json
+from ipdb import set_trace
 
 import torch
 from torch.utils.data import DataLoader
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import ModelCheckpoint
 
-from asteroid.data.wsj0_mix import WSJ2mixDataset 
+from asteroid.data.wsj0_mix import WSJ2mixDataset, BucketingSampler, \
+        collate_fn
 from asteroid.engine.system import System
 from asteroid.losses import PITLossWrapper, pairwise_mse
 from asteroid.losses import deep_clustering_loss
@@ -17,7 +20,7 @@ import asteroid.filterbanks as fb
 from asteroid.filterbanks.transforms import take_mag
 from model import make_model_and_optimizer
 
-EPS = torch.finfo(torch.float).eps
+EPS = torch.finfo(torch.float32).eps
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--gpus', type=str, help='list of GPUs', default='-1')
@@ -36,7 +39,7 @@ class DcSystem(System):
                  val_loader=val_loader, scheduler=scheduler, config=config)
         self.enc = fb.Encoder(fb.STFTFB(**config['filterbank']))
 
-    def common_step(self, batch, batch_nb):
+    def common_step(self, batch, batch_nb, train=False):
         inputs, targets, masks = self.unpack_data(batch)
         est_targets = self(inputs)
         spec = take_mag(self.enc(inputs.unsqueeze(1)))
@@ -70,28 +73,34 @@ def handle_multiple_loss(est_heads, targets, true_real_masks, inputs, alpha=1):
         Sum of the deep clustering and PIT loss
     """
     embedding, est_masks = est_heads
-    dc_loss = deep_clustering_loss(embedding, targets)
-    pit_loss_batch = pit_loss(est_masks * inputs.unsqueeze(1),
-                              true_real_masks * inputs.unsqueeze(1))
-    return dc_loss.mean() + alpha * pit_loss_batch
+    #dc_loss = deep_clustering_loss(embedding, targets)
+    #pit_loss_batch = pit_loss(est_masks * inputs.unsqueeze(1),
+    #                          true_real_masks * inputs.unsqueeze(1))
+    pit_loss_batch = pit_loss(est_masks, true_real_masks)
+    #return dc_loss.mean() + alpha * pit_loss_batch
+    #return dc_loss.mean()
+    return pit_loss_batch
 
 def main(conf):
     train_set = WSJ2mixDataset(conf['data']['tr_wav_len_list'],
                                conf['data']['wav_base_path']+'/tr',
-                               sample_rate=conf['data']['sample_rate'],
-                               segment=conf['data']['segment'])
+                               sample_rate=conf['data']['sample_rate'])
     val_set = WSJ2mixDataset(conf['data']['cv_wav_len_list'],
                              conf['data']['wav_base_path']+'/cv',
-                             sample_rate=conf['data']['sample_rate'],
-                             segment=conf['data']['segment'])
-    train_loader = DataLoader(train_set, shuffle=True,
-                              batch_size=conf['data']['batch_size'],
-                              num_workers=conf['data']['num_workers'],
-                              drop_last=True)
-    val_loader = DataLoader(val_set, shuffle=True,
-                            batch_size=conf['data']['batch_size'],
-                            num_workers=conf['data']['num_workers'],
-                            drop_last=True)
+                             sample_rate=conf['data']['sample_rate'])
+    train_sampler = BucketingSampler(train_set,
+                                     batch_size=conf['data']['batch_size'])
+    valid_sampler = BucketingSampler(val_set,
+                                     batch_size=conf['data']['batch_size'])
+
+    train_loader = DataLoader(train_set, 
+                              batch_sampler=train_sampler,
+                              collate_fn=collate_fn,
+                              num_workers=conf['data']['num_workers'])
+    val_loader = DataLoader(val_set, 
+                            batch_sampler=valid_sampler,
+                            collate_fn=collate_fn,
+                            num_workers=conf['data']['num_workers'])
     model, optimizer = make_model_and_optimizer(conf)
     exp_dir = conf['main_args']['exp_dir']
     os.makedirs(exp_dir, exist_ok=True)
@@ -118,15 +127,18 @@ def main(conf):
                          train_percent_check=1.0  # Useful for fast experiment
                         )
     trainer.fit(system)
-    torch.save(system.model.state_dict(), os.path.join(exp_dir, 'final.pth'))
+    with open(os.path.join(exp_dir, "best_k_models.json"), "w") as f:
+        json.dump(checkpoint.best_k_models, f, indent=0)
+    #torch.save(system.model.state_dict(), os.path.join(exp_dir, 'final.pth'))
 
 if __name__ == '__main__':
     import yaml
     from asteroid.utils import prepare_parser_from_dict, parse_args_as_dict
 
-    with open('conf.yml') as f:
+    with open('local/conf.yml') as f:
         def_conf = yaml.safe_load(f)
     parser = prepare_parser_from_dict(def_conf, parser=parser)
     arg_dic, plain_args = parse_args_as_dict(parser, return_plain_args=True)
+    set_trace()
     print(arg_dic)
     main(arg_dic)

--- a/egs/wsj0-mix/DeepClustering/utils
+++ b/egs/wsj0-mix/DeepClustering/utils
@@ -1,0 +1,1 @@
+../../wham/ConvTasNet/utils

--- a/egs/wsj0-mix/create_meta_files.py
+++ b/egs/wsj0-mix/create_meta_files.py
@@ -1,0 +1,31 @@
+import os
+import argparse
+from ipdb import set_trace
+
+from asteroid.data.wsj0_mix import create_wav_id_sample_count_list
+
+parser = argparse.ArgumentParser()
+parser.add_argument('base_path', type=str,\
+        help='base path containing tr, tt and cv')
+parser.add_argument('dest_folder', type=str,\
+        help='Path to save the metadata')
+args = parser.parse_args()
+
+datasets = ['tr', 'cv', 'tt']
+
+def create_meta_data(base_path, dest_folder):
+    for _dataset in datasets:
+        ds_base = os.path.join(base_path, _dataset, 'mix')
+        meta_dest = os.path.join(dest_folder, _dataset+'.wavid.samples')
+        if os.path.exists(meta_dest):
+            print('{} already exists. Remove it and rerun'.format(meta_dest))
+            exit(1)
+        if not os.path.exists(dest_folder):
+            os.makedirs(dest_folder)
+        create_wav_id_sample_count_list(ds_base, meta_dest)
+
+
+
+if __name__ == '__main__':
+    set_trace()
+    create_meta_data(args.base_path, args.dest_folder)


### PR DESCRIPTION
Deep clustering updates 
=> Create collate functions to ensure the seq length of batch elements are  the same
=> Bucketing sampler to ensure each element of the batch are approximately of the same seq length, this avoid chopping of large parts of the dataset
=> Fix the bug where different random samples were taken for mixture and sources
=> Python code to create wav id sample count files
=> Introduce VAD mask for deep clustering
=> Normalize the deep clustering loss
=> Fix bug in the chimera++ model where projection view mixes up the seq and source indexes
=> Take log of spectra as input to train the model
=> Simple eval script which needs to be enhanced
=> Training script without pytorch lightning (To be made compatible with the core asteroid)