### PR TITLE
First draft of MUSDB18 dataset

### DIFF
--- a/asteroid/data/__init__.py
+++ b/asteroid/data/__init__.py
@@ -3,3 +3,4 @@ from .whamr_dataset import WhamRDataset
 from .dns_dataset import DNSDataset
 from .librimix_dataset import LibriMix
 from .wsj0_mix import Wsj0mixDataset
+from .musdb18_dataset import MUSDB18Dataset

--- a/asteroid/data/musdb18_dataset.py
+++ b/asteroid/data/musdb18_dataset.py
@@ -7,90 +7,114 @@ import soundfile as sf
 
 
 class MUSDB18Dataset(torch.utils.data.Dataset):
-    """A dataset of that assumes audio sources to be stored
-    in track (subb)folder where each folder has a fixed number of sources.
-    For each track the users specifies a list of `source_files` and
-    a common `suffix`.
-    A linear mix is performed on the fly by summing the target and
-    the inferers up.
+    """MUSDB18 music separation dataset
+
+    The dataset consists of 150 full lengths music tracks (~10h duration) of
+    different genres along with their isolated stems:
+        `drums`, `bass`, `vocals` and `others`.
+
+    Out-of-the-box, asteroid does only support MUSDB18-HQ which comes as
+    uncompressed WAV files. To use the MUSDB18, please convert it to WAV first:
+
+    MUSDB18 HQ: https://zenodo.org/record/3338373   
+    MUSDB18     https://zenodo.org/record/1117372 
+
+    Note: The datasets are hosted on Zenodo and require that users
+          request access, since the tracks can only be used for
+          academic purposes. We manually check this requests.
+
+    This dataset asssumes music tracks in (sub)folders where each folder
+    has a fixed number of sources (defaults to 4). For each track, a list
+    of `sources` and a common `suffix` can be specified.
+    A linear mix is performed on the fly by summing up the sources
 
     Due to the fact that all tracks comprise the exact same set
-    of sources, random track mixing augmentation technique
-    can be used, where sources from different tracks are mixed
-    together.
+    of sources, random track mixing can be used can be used,
+    where sources from different tracks are mixed together.
 
-    Example
-    =======
-    train/1/vocals.wav ---------------\
-    train/1/drums.wav -----------------+--> input (mix), output[target]
-    train/1/bass.wav ------------------|
-    train/1/other.wav ----------------/
+    Folder Structure:
+        train/1/vocals.wav ---------------\
+        train/1/drums.wav -----------------+--> input (mix), output[target]
+        train/1/bass.wav ------------------|
+        train/1/other.wav ----------------/
+
+    Args:
+        root (str): Root path of dataset
+        sources (:obj:`list` of :obj:`str`, optional): List of source names.
+            Defaults to MUSDB18 4 stem scenario: `vocals`, `drums`, `bass`, `other`.
+        suffix (str, optional): Filename suffix, defaults to `.wav`.
+        split (str, optional): Dataset subfolder, defaults to `train`.
+        subset (:obj:`list` of :obj:`str`, optional): Selects a specific of
+            list of tracks to be loaded, defaults to `None` (loads all tracks).
+        seq_duration (float, optional): Duration of segments in seconds,
+            defaults to ``None`` which loads the full-length audio tracks.
+        samples_per_track (int, optional):
+            Number of samples yielded from each track, can be used to increase 
+            dataset size, defaults to `1`.
+        random_segments (boolean, optional): Enables random offset for track segments.
+        random_track_mix boolean: enables mixing of random sources from
+            different tracks to assemble mix.
+        source_augmentations (:obj:`list` of `obj`:`callable`):
+            list of augmentation function names,
+            defaults to no-op augmentations (input = output)
+        sample_rate (int, optional): Samplerate of files in dataset.
+
+    Attributes:
+        root (str): Root path of dataset
+        sources (:obj:`list` of :obj:`str`, optional): List of source names.
+            Defaults to MUSDB18 4 stem scenario: `vocals`, `drums`, `bass`, `other`.
+        suffix (str, optional): Filename suffix, defaults to `.wav`.
+        split (str, optional): Dataset subfolder, defaults to `train`.
+        subset (:obj:`list` of :obj:`str`, optional): Selects a specific of
+            list of tracks to be loaded, defaults to `None` (loads all tracks).
+        seq_duration (float, optional): Duration of segments in seconds,
+            defaults to ``None`` which loads the full-length audio tracks.
+        samples_per_track (int, optional):
+            Number of samples yielded from each track, can be used to increase 
+            dataset size, defaults to `1`.
+        random_segments (boolean, optional): Enables random offset for track segments.
+        random_track_mix boolean: enables mixing of random sources from
+            different tracks to assemble mix.
+        source_augmentations (:obj:`list` of `obj`:`callable`):
+            list of augmentation function names,
+            defaults to no-op augmentations (input = output)
+        sample_rate (int, optional): Samplerate of files in dataset.
+        tracks (:obj:`list` of :obj:`Dict`): List of track metadata
 
     """
     def __init__(self,
                  root,
+                 sources=['vocals', 'bass', 'drums', 'other'],
+                 suffix='.wav',
                  split='train',
                  subset=None,
-                 source_files=['vocals', 'bass', 'drums', 'other'],
-                 suffix='.wav',
                  seq_duration=None,
                  samples_per_track=1,
-                 random_chunks=False,
+                 random_segments=False,
                  random_track_mix=False,
                  source_augmentations=lambda audio: audio,
                  sample_rate=44100):
 
-        """MUSDB18 torch.data.Dataset that samples from the MUSDB18 tracks
-        using track and excerpts with replacement.
-
-        Parameters
-        ----------
-        root : str
-            root path of MUSDB18HQ, please download from zenodo
-        suffix : str
-            specify the filename suffice, defaults to `.wav`
-        split : str
-            select dataset subfolder, defaults to ``train``.
-        subsets : list(str)
-            selects a list of track folders, defaults to `None` 
-            which loads all tracks
-        seq_duration : float
-            training is performed in chunks of ``seq_duration`` (in seconds,
-            defaults to ``None`` which loads the full audio track
-        samples_per_track : int
-            sets the number of samples, yielded from each track
-            Defaults to 1
-        source_augmentations : list[callables]
-            provide list of augmentation function that take a multi-channel
-            audio file of shape (src, samples) as input and output. Defaults to
-            no-augmentations (input = output)
-        random_track_mix : boolean
-            randomly mixes sources from different tracks to assemble a
-            custom mix. This augmenation is only applied for the train subset.
-        args, kwargs : additional keyword arguments
-            used to add further control for the musdb dataset
-            initialization function.
-        """
         self.root = Path(root).expanduser()
         self.split = split
         self.sample_rate = sample_rate
         self.seq_duration = seq_duration
         self.random_track_mix = random_track_mix
-        self.random_chunks = random_chunks
+        self.random_segments = random_segments
         self.source_augmentations = source_augmentations
-        self.source_files = source_files
+        self.sources = sources
         self.suffix = suffix
         self.subset = subset
         self.samples_per_track = samples_per_track
         self.tracks = list(self.get_tracks())
         if not self.tracks:
-            raise RuntimeError("No tracks found")
+            raise RuntimeError("No tracks found.")
 
     def __getitem__(self, index):
         # assemble the mixture of target and interferers
         audio_sources = {}
         # load interferers
-        for source in self.source_files:
+        for source in self.sources:
             # optionally select a random track for each source
             if self.random_track_mix:
                 track_id = random.choice(range(len(self.tracks)))
@@ -98,7 +122,7 @@ class MUSDB18Dataset(torch.utils.data.Dataset):
                 track_id = index // self.samples_per_track
 
             track_path = self.tracks[track_id]['path']
-            if self.random_chunks:
+            if self.random_segments:
                 min_duration = self.tracks[track_id]['min_duration']
                 start = random.uniform(0, min_duration - self.seq_duration)
 
@@ -139,7 +163,7 @@ class MUSDB18Dataset(torch.utils.data.Dataset):
                     continue
 
                 source_paths = [
-                    track_path / (s + self.suffix) for s in self.source_files
+                    track_path / (s + self.suffix) for s in self.sources
                 ]
                 if not all(sp.exists() for sp in source_paths):
                     print(

--- a/asteroid/data/musdb18_dataset.py
+++ b/asteroid/data/musdb18_dataset.py
@@ -46,7 +46,7 @@ class MUSDB18Dataset(torch.utils.data.Dataset):
         split (str, optional): Dataset subfolder, defaults to `train`.
         subset (:obj:`list` of :obj:`str`, optional): Selects a specific of
             list of tracks to be loaded, defaults to `None` (loads all tracks).
-        seq_duration (float, optional): Duration of segments in seconds,
+        segment (float, optional): Duration of segments in seconds,
             defaults to ``None`` which loads the full-length audio tracks.
         samples_per_track (int, optional):
             Number of samples yielded from each track, can be used to increase 
@@ -67,7 +67,7 @@ class MUSDB18Dataset(torch.utils.data.Dataset):
         split (str, optional): Dataset subfolder, defaults to `train`.
         subset (:obj:`list` of :obj:`str`, optional): Selects a specific of
             list of tracks to be loaded, defaults to `None` (loads all tracks).
-        seq_duration (float, optional): Duration of segments in seconds,
+        segment (float, optional): Duration of segments in seconds,
             defaults to ``None`` which loads the full-length audio tracks.
         samples_per_track (int, optional):
             Number of samples yielded from each track, can be used to increase 
@@ -88,7 +88,7 @@ class MUSDB18Dataset(torch.utils.data.Dataset):
                  suffix='.wav',
                  split='train',
                  subset=None,
-                 seq_duration=None,
+                 segment=None,
                  samples_per_track=1,
                  random_segments=False,
                  random_track_mix=False,
@@ -98,7 +98,7 @@ class MUSDB18Dataset(torch.utils.data.Dataset):
         self.root = Path(root).expanduser()
         self.split = split
         self.sample_rate = sample_rate
-        self.seq_duration = seq_duration
+        self.segment = segment
         self.random_track_mix = random_track_mix
         self.random_segments = random_segments
         self.source_augmentations = source_augmentations
@@ -124,14 +124,14 @@ class MUSDB18Dataset(torch.utils.data.Dataset):
             track_path = self.tracks[track_id]['path']
             if self.random_segments:
                 min_duration = self.tracks[track_id]['min_duration']
-                start = random.uniform(0, min_duration - self.seq_duration)
+                start = random.uniform(0, min_duration - self.segment)
 
             # loads the full track duration
             start = int(start * self.sample_rate)
             # check if dur is none
-            if self.seq_duration:
+            if self.segment:
                 # stop in soundfile is calc in samples, not seconds
-                stop = start + int(self.seq_duration * self.sample_rate)
+                stop = start + int(self.segment * self.sample_rate)
             else:
                 # set to None for reading complete file
                 stop = None
@@ -183,10 +183,10 @@ class MUSDB18Dataset(torch.utils.data.Dataset):
                     )
                     continue
 
-                if self.seq_duration is not None:
+                if self.segment is not None:
                     # get minimum duration of track
                     min_duration = min(i.duration for i in infos)
-                    if min_duration > self.seq_duration:
+                    if min_duration > self.segment:
                         yield({
                             'path': track_path,
                             'min_duration': min_duration

--- a/asteroid/data/musdb18_dataset.py
+++ b/asteroid/data/musdb18_dataset.py
@@ -1,0 +1,174 @@
+from pathlib import Path
+import torch.utils.data
+import random
+import torch
+import tqdm
+import soundfile as sf
+
+
+class MUSDB18Dataset(torch.utils.data.Dataset):
+    """A dataset of that assumes audio sources to be stored
+    in track (subb)folder where each folder has a fixed number of sources.
+    For each track the users specifies a list of `source_files` and
+    a common `suffix`.
+    A linear mix is performed on the fly by summing the target and
+    the inferers up.
+
+    Due to the fact that all tracks comprise the exact same set
+    of sources, random track mixing augmentation technique
+    can be used, where sources from different tracks are mixed
+    together.
+
+    Example
+    =======
+    train/1/vocals.wav ---------------\
+    train/1/drums.wav -----------------+--> input (mix), output[target]
+    train/1/bass.wav ------------------|
+    train/1/other.wav ----------------/
+
+    """
+    def __init__(self,
+                 root,
+                 split='train',
+                 subset=None,
+                 source_files=['vocals', 'bass', 'drums', 'other'],
+                 suffix='.wav',
+                 seq_duration=None,
+                 samples_per_track=1,
+                 random_chunks=False,
+                 random_track_mix=False,
+                 source_augmentations=lambda audio: audio,
+                 sample_rate=44100):
+
+        """MUSDB18 torch.data.Dataset that samples from the MUSDB18 tracks
+        using track and excerpts with replacement.
+
+        Parameters
+        ----------
+        root : str
+            root path of MUSDB18HQ, please download from zenodo
+        suffix : str
+            specify the filename suffice, defaults to `.wav`
+        split : str
+            select dataset subfolder, defaults to ``train``.
+        subsets : list(str)
+            selects a list of track folders, defaults to `None` 
+            which loads all tracks
+        seq_duration : float
+            training is performed in chunks of ``seq_duration`` (in seconds,
+            defaults to ``None`` which loads the full audio track
+        samples_per_track : int
+            sets the number of samples, yielded from each track
+            Defaults to 1
+        source_augmentations : list[callables]
+            provide list of augmentation function that take a multi-channel
+            audio file of shape (src, samples) as input and output. Defaults to
+            no-augmentations (input = output)
+        random_track_mix : boolean
+            randomly mixes sources from different tracks to assemble a
+            custom mix. This augmenation is only applied for the train subset.
+        args, kwargs : additional keyword arguments
+            used to add further control for the musdb dataset
+            initialization function.
+        """
+        self.root = Path(root).expanduser()
+        self.split = split
+        self.sample_rate = sample_rate
+        self.seq_duration = seq_duration
+        self.random_track_mix = random_track_mix
+        self.random_chunks = random_chunks
+        self.source_augmentations = source_augmentations
+        self.source_files = source_files
+        self.suffix = suffix
+        self.subset = subset
+        self.samples_per_track = samples_per_track
+        self.tracks = list(self.get_tracks())
+        if not self.tracks:
+            raise RuntimeError("No tracks found")
+
+    def __getitem__(self, index):
+        # assemble the mixture of target and interferers
+        audio_sources = {}
+        # load interferers
+        for source in self.source_files:
+            # optionally select a random track for each source
+            if self.random_track_mix:
+                track_id = random.choice(range(len(self.tracks)))
+            else:
+                track_id = index // self.samples_per_track
+
+            track_path = self.tracks[track_id]['path']
+            if self.random_chunks:
+                min_duration = self.tracks[track_id]['min_duration']
+                start = random.uniform(0, min_duration - self.seq_duration)
+
+            # loads the full track duration
+            start = int(start * self.sample_rate)
+            # check if dur is none
+            if self.seq_duration:
+                # stop in soundfile is calc in samples, not seconds
+                stop = start + int(self.seq_duration * self.sample_rate)
+            else:
+                # set to None for reading complete file
+                stop = None
+
+            audio, _ = sf.read(
+                Path(track_path / source).with_suffix(self.suffix),
+                always_2d=True,
+                start=start,
+                stop=stop
+            )
+            audio = torch.tensor(audio.T, dtype=torch.float)
+            audio = self.source_augmentations(audio)
+            audio_sources[source] = audio
+
+        # apply linear mix over source index=0
+        audio_mix = torch.stack(list(audio_sources.values())).sum(0)
+        return audio_mix, audio_sources
+
+    def __len__(self):
+        return len(self.tracks) * self.samples_per_track
+
+    def get_tracks(self):
+        """Loads input and output tracks"""
+        p = Path(self.root, self.split)
+        for track_path in tqdm.tqdm(p.iterdir()):
+            if track_path.is_dir():
+                if self.subset and track_path.stem not in self.subset:
+                    # skip this track
+                    continue
+
+                source_paths = [
+                    track_path / (s + self.suffix) for s in self.source_files
+                ]
+                if not all(sp.exists() for sp in source_paths):
+                    print(
+                        "Exclude track due to non-existing source",
+                        track_path
+                    )
+                    continue
+
+                # get metadata
+                infos = list(map(sf.info, source_paths))
+                if not all(
+                    i.samplerate == self.sample_rate for i in infos
+                ):
+                    print(
+                        "Exclude track due to different sample rate ",
+                        track_path
+                    )
+                    continue
+
+                if self.seq_duration is not None:
+                    # get minimum duration of track
+                    min_duration = min(i.duration for i in infos)
+                    if min_duration > self.seq_duration:
+                        yield({
+                            'path': track_path,
+                            'min_duration': min_duration
+                        })
+                else:
+                    yield({
+                        'path': track_path,
+                        'min_duration': None
+                    })

--- a/egs/musdb18/OpenUnmix/test_dataloader.py
+++ b/egs/musdb18/OpenUnmix/test_dataloader.py
@@ -79,13 +79,13 @@ if __name__ == "__main__":
         split='train',
         source_augmentations=source_augmentations,
         random_track_mix=args.random_track_mix,
-        random_chunks=True,
-        seq_duration=args.seq_dur,
+        segment=args.seq_dur,
+        random_segments=True,
         samples_per_track=64,
         **dataset_kwargs
     )
 
-    # List of MUSDB18 validation tracks
+    # List of MUSDB18 validation tracks as being used in the `musdb` package
     # See https://github.com/sigsep/sigsep-mus-db/blob/master/musdb/configs/mus.yaml#L41
     validation_tracks = [
         'Actions - One Minute Smile',
@@ -107,14 +107,14 @@ if __name__ == "__main__":
     valid_dataset = MUSDB18Dataset(
         split='train',
         subset=validation_tracks,
-        seq_duration=None,
+        segment=None,
         **dataset_kwargs
     )
 
     test_dataset = MUSDB18Dataset(
         split='test',
         subset=None,
-        seq_duration=None,
+        segment=None,
         **dataset_kwargs
     )
 

--- a/egs/musdb18/OpenUnmix/test_dataloader.py
+++ b/egs/musdb18/OpenUnmix/test_dataloader.py
@@ -1,0 +1,134 @@
+from asteroid.data import MUSDB18Dataset
+import argparse
+import torch
+from pathlib import Path
+import tqdm
+
+
+class Compose(object):
+    """Composes several augmentation transforms.
+    Args:
+        augmentations: list of augmentations to compose.
+    """
+
+    def __init__(self, transforms):
+        self.transforms = transforms
+
+    def __call__(self, audio):
+        for transform in self.transforms:
+            audio = transform(audio)
+        return audio
+
+
+def _augment_gain(audio, low=0.25, high=1.25):
+    """Applies a random gain to each source between `low` and `high`"""
+    gain = low + torch.rand(1) * (high - low)
+    return audio * gain
+
+
+def _augment_channelswap(audio):
+    """Randomly swap channels of stereo sources"""
+    if audio.shape[0] == 2 and torch.FloatTensor(1).uniform_() < 0.5:
+        return torch.flip(audio, [0])
+
+    return audio
+
+
+if __name__ == "__main__":
+    """dataset tests -> these parameters will go into recipes"""
+    parser = argparse.ArgumentParser(description='MUSDB18 dataset test')
+
+    parser.add_argument(
+        '--root', type=str, help='root path of dataset'
+    )
+
+    parser.add_argument('--seed', type=int, default=42)
+
+    parser.add_argument(
+        '--seq-dur', type=float, default=6.0,
+        help='Duration of <=0.0 will result in the full audio'
+    )
+
+    parser.add_argument(
+        '--samples-per-track', type=int, default=64,
+        help='draws a fixed number of samples per track'
+    )
+
+    parser.add_argument(
+        '--random-track-mix',
+        action='store_true', default=False,
+        help='Apply random track mixing augmentation'
+    )
+    parser.add_argument(
+        '--source-augmentations', type=str, nargs='+',
+        default=['gain', 'channelswap']
+    )
+    parser.add_argument('--batch-size', type=int, default=16)
+
+    args = parser.parse_args()
+
+    dataset_kwargs = {
+        'root': Path(args.root),
+    }
+
+    source_augmentations = Compose(
+        [globals()['_augment_' + aug] for aug in args.source_augmentations]
+    )
+
+    train_dataset = MUSDB18Dataset(
+        split='train',
+        source_augmentations=source_augmentations,
+        random_track_mix=args.random_track_mix,
+        random_chunks=True,
+        seq_duration=args.seq_dur,
+        samples_per_track=64,
+        **dataset_kwargs
+    )
+
+    # List of MUSDB18 validation tracks
+    # See https://github.com/sigsep/sigsep-mus-db/blob/master/musdb/configs/mus.yaml#L41
+    validation_tracks = [
+        'Actions - One Minute Smile',
+        'Clara Berry And Wooldog - Waltz For My Victims',
+        'Johnny Lokke - Promises & Lies',
+        'Patrick Talbot - A Reason To Leave',
+        'Triviul - Angelsaint',
+        'Alexander Ross - Goodbye Bolero',
+        'Fergessen - Nos Palpitants',
+        'Leaf - Summerghost',
+        'Skelpolu - Human Mistakes',
+        'Young Griffo - Pennies',
+        'ANiMAL - Rockshow',
+        'James May - On The Line',
+        'Meaxic - Take A Step',
+        'Traffic Experiment - Sirens'
+    ]
+
+    valid_dataset = MUSDB18Dataset(
+        split='train',
+        subset=validation_tracks,
+        seq_duration=None,
+        **dataset_kwargs
+    )
+
+    test_dataset = MUSDB18Dataset(
+        split='test',
+        subset=None,
+        seq_duration=None,
+        **dataset_kwargs
+    )
+
+    print("Number of train tracks: ", len(train_dataset.tracks))
+    print("Number of validation tracks: ", len(valid_dataset.tracks))
+    print("Number of test tracks: ", len(test_dataset.tracks))
+
+    print("Number of train samples: ", len(train_dataset))
+    print("Number of validation samples: ", len(valid_dataset))
+    print("Number of test samples: ", len(test_dataset))
+
+    train_sampler = torch.utils.data.DataLoader(
+        train_dataset, batch_size=args.batch_size, shuffle=True, num_workers=0,
+    )
+
+    for x, y in tqdm.tqdm(train_sampler):
+        pass

--- a/egs/musdb18/README.md
+++ b/egs/musdb18/README.md
@@ -1,0 +1,5 @@
+### About the MUSDB18 Dataset
+
+The musdb18 is a dataset of 150 full lengths music tracks (~10h duration) of different genres along with their isolated drums, bass, vocals and others stems.
+
+More info [here](https://sigsep.github.io/datasets/musdb.html).


### PR DESCRIPTION
this PR adds the MUSDB18 dataset and dataloaders as well as a smoke test recipe that includes optimal parameters for training MUSDB18 models.

This dataset is a variant of the [FixedSourcesTrackFolderDataset](https://github.com/sigsep/open-unmix-pytorch/blob/master/data.py#L414) from the Open-Unmix repository.

* it was stripped down to the most basic use cases
* dataloading is limited to soundfile to not increase the number of dependencies on asteroid

This means the dataset is only compatible with MUSDB18HQ and not work with the stems version of MUSDB18. Documentation and scripts to convert MUSDB18 to wav will be added later.