### PR TITLE
[src & tests] Depend on torch_optimizer for optimizer

### DIFF
--- a/asteroid/engine/optimizers.py
+++ b/asteroid/engine/optimizers.py
@@ -1,4 +1,11 @@
-from torch import optim
+from torch.optim.optimizer import Optimizer
+from torch.optim import (
+    Adam, RMSprop, SGD, Adadelta, Adagrad, Adamax, AdamW, ASGD
+)
+from torch_optimizer import (
+    AccSGD, AdaBound, AdaMod, DiffGrad, Lamb, NovoGrad, PID, QHAdam,
+    QHM, RAdam, SGDW, Yogi, Ranger, RangerQH, RangerVA
+)
 
 
 def make_optimizer(params, optimizer='adam', **kwargs):
@@ -21,43 +28,22 @@ def make_optimizer(params, optimizer='adam', **kwargs):
     return get(optimizer)(params, **kwargs)
 
 
-def adam(params, lr=0.001, **kwargs):
-    return optim.Adam(params, lr=lr, **kwargs)
-
-
-def sgd(params, lr=0.001, **kwargs):
-    return optim.SGD(params, lr=lr, **kwargs)
-
-
-def rmsprop(params, lr=0.001, **kwargs):
-    return optim.RMSprop(params, lr=lr, **kwargs)
-
-
-def ranger(params, lr=0.001, **kwargs):
-    from asranger import Ranger
-    return Ranger(params, lr=lr, **kwargs)
-
-
 def get(identifier):
     """ Returns an optimizer function from a string. Returns its input if it
     is callable (already a :class:`torch.optim.Optimizer` for example).
 
     Args:
-        identifier (str or Callable or None): the optimizer identifier.
+        identifier (str or Callable): the optimizer identifier.
 
     Returns:
         :class:`torch.optim.Optimizer` or None
     """
-    if identifier is None:
-        return None
-    elif isinstance(identifier, optim.Optimizer):
+    if isinstance(identifier, Optimizer):
         return identifier
     elif isinstance(identifier, str):
-        cls = globals().get(identifier)
+        to_get = {k.lower(): v for k, v in globals().items()}
+        cls = to_get.get(identifier.lower())
         if cls is None:
-            raise ValueError('Could not interpret optimizer identifier: ' +
-                             str(identifier))
+            raise ValueError(f'Could not interpret optimizer : {str(identifier)}')
         return cls
-    else:
-        raise ValueError('Could not interpret optimizer identifier: ' +
-                         str(identifier))
+    raise ValueError(f'Could not interpret optimizer : {str(identifier)}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pytorch-lightning==0.6.0
 pb_bss_eval>=0.0.2
 asranger>=0.0.5
 torch_stoi>=0.0.1
-torch_optimizer>=0.0.1
+torch_optimizer>=0.0.1a12

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytorch-lightning==0.6.0
 pb_bss_eval>=0.0.2
 asranger>=0.0.5
 torch_stoi>=0.0.1
+torch_optimizer>=0.0.1

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
                       'pytorch-lightning==0.6.0',
                       'pb_bss_eval',
                       'asranger',
-                      'torch_stoi'
+                      'torch_stoi',
+                      'torch_optimizer',
                       ],
     extras_require={
         'visualize': ['seaborn>=0.9.0'],

--- a/tests/engine/optimizers_test.py
+++ b/tests/engine/optimizers_test.py
@@ -1,7 +1,7 @@
 import pytest
 from torch import nn, optim
 from asteroid.engine import optimizers
-from asranger import Ranger
+from torch_optimizer import Ranger
 
 
 def optim_mapping():
@@ -16,6 +16,15 @@ def optim_mapping():
 
 global_model = nn.Sequential(nn.Linear(10, 10),
                              nn.ReLU())
+
+
+@pytest.mark.parametrize("opt", [
+    'Adam', 'RMSprop', 'SGD', 'Adadelta', 'Adagrad', 'Adamax', 'AdamW', 'ASGD',
+    'AccSGD', 'AdaBound', 'AdaMod', 'DiffGrad', 'Lamb', 'NovoGrad', 'PID',
+    'QHAdam', 'QHM', 'RAdam', 'SGDW', 'Yogi', 'Ranger', 'RangerQH', 'RangerVA'
+])
+def test_all_get(opt):
+    asteroid_optim = optimizers.get(opt)(global_model.parameters(), lr=1e-3)
 
 
 @pytest.mark.parametrize("opt_tuple", optim_mapping())
@@ -39,10 +48,6 @@ def test_get_errors(wrong):
     with pytest.raises(ValueError):
         # Should raise for anything not a Optimizer instance + unknown string
         optimizers.get(wrong)
-
-
-def test_get_none():
-    assert optimizers.get(None) is None
 
 
 def test_make_optimizer():


### PR DESCRIPTION
All optimizers available [here](https://github.com/jettify/pytorch-optimizer) are _getable_ with from string.

The logic stays the same as before and optimizer supported before are still the same. It just adds more supported optimizers to Asteroid.