### PR TITLE
Publishing pretrained models !!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Project specific
+uploader_info.yml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/asteroid/__init__.py
+++ b/asteroid/__init__.py
@@ -1,3 +1,5 @@
+import pathlib
 from .utils import deprecation_utils, torch_utils
 
+project_root = str(pathlib.Path(__file__).expanduser().absolute().parent.parent)
 __version__ = '0.2.1'

--- a/asteroid/data/wham_dataset.py
+++ b/asteroid/data/wham_dataset.py
@@ -166,3 +166,40 @@ class WhamDataset(data.Dataset):
             mixture = normalize_tensor_wav(mixture, eps=EPS, std=m_std)
             sources = normalize_tensor_wav(sources, eps=EPS, std=m_std)
         return mixture, sources
+
+    def get_infos(self):
+        """ Get dataset infos (for publishing models).
+
+        Returns:
+            dict, dataset infos with keys `dataset`, `task` and `licences`.
+        """
+        infos = dict()
+        infos['dataset'] = self.dataset_name
+        infos['task'] = self.task
+        if self.task == 'sep_clean':
+            data_license = [wsj0_license]
+        else:
+            data_license = [wsj0_license, wham_noise_license]
+        infos['licenses'] = data_license
+        return infos
+
+
+wsj0_license = dict(
+    title='CSR-I (WSJ0) Complete',
+    title_link='https://catalog.ldc.upenn.edu/LDC93S6A',
+    author='LDC',
+    author_link='https://www.ldc.upenn.edu/',
+    license='LDC User Agreement for Non-Members',
+    license_link='https://catalog.ldc.upenn.edu/license/ldc-non-members-agreement.pdf',
+    non_commercial=True
+)
+
+wham_noise_license = dict(
+    title='The WSJ0 Hipster Ambient Mixtures dataset',
+    title_link='http://wham.whisper.ai/',
+    author='Whisper.ai',
+    author_link='https://whisper.ai/',
+    license='CC BY-NC 4.0',
+    license_link='https://creativecommons.org/licenses/by-nc/4.0/',
+    non_commercial=True,
+)

--- a/asteroid/models/README.md
+++ b/asteroid/models/README.md
@@ -1,0 +1,7 @@
+### Publishing models
+
+- First, create a account on [Zenodo](https://zenodo.org/) 
+(you can log in with GitHub directly)
+- Then [create an access token](https://zenodo.org/account/settings/applications/tokens/new/), 
+we'll need one to upload anything.
+

--- a/asteroid/models/__init__.py
+++ b/asteroid/models/__init__.py
@@ -3,4 +3,4 @@ from .conv_tasnet import ConvTasNet
 from .dprnn_tasnet import DPRNNTasNet
 
 # Sharing-related
-from .publisher import save_publishable
+from .publisher import save_publishable, upload_publishable

--- a/asteroid/models/__init__.py
+++ b/asteroid/models/__init__.py
@@ -1,2 +1,6 @@
+# Models
 from .conv_tasnet import ConvTasNet
 from .dprnn_tasnet import DPRNNTasNet
+
+# Sharing-related
+from .publisher import save_publishable

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -3,6 +3,7 @@ from torch import nn
 import numpy as np
 
 from .. import torch_utils
+from .. import __version__ as asteroid_version
 
 
 class BaseTasNet(nn.Module):
@@ -121,6 +122,7 @@ class BaseTasNet(nn.Module):
         Returns:
             dict, serialized model with keys `model_args` and `state_dict`.
         """
+        import pytorch_lightning as pl  # Not used in torch.hub
         model_conf = dict()
         fb_config = self.encoder.filterbank.get_config()
         masknet_config = self.masker.get_config()
@@ -129,6 +131,15 @@ class BaseTasNet(nn.Module):
             raise AssertionError("Filterbank and Mask network config share"
                                  "common keys. Merging them is not safe.")
         # Merge all args under model_args.
+        model_conf['model_name'] = self.__class__.__name__
         model_conf['model_args'] = {**fb_config, **masknet_config}
         model_conf['state_dict'] = self.state_dict()
+        # Additional infos
+        infos = dict()
+        infos['software_versions'] = dict(
+            torch_version=torch.__version__,
+            pytorch_lightning_version=pl.__version__,
+            asteroid_version=asteroid_version,
+        )
+        model_conf['infos'] = infos
         return model_conf

--- a/asteroid/models/publisher.py
+++ b/asteroid/models/publisher.py
@@ -1,0 +1,332 @@
+import os
+import torch
+import subprocess
+from pprint import pprint
+
+from .zenodo import Zenodo
+
+PLEASE_PUBLISH = (
+    "\nDon't forget to share your pretrained models at "
+    "https://zenodo.org/communities/asteroid-models/ ! =)\n"
+    "You can directly use our CLI for that, run this: \n"
+    "`asteroid-upload {} --uploader \"Your name here\"`\n"
+)
+
+HREF = '<a href="{}">{}</a>'
+CC_SA = 'Attribution-ShareAlike 3.0 Unported'
+CC_SA_LINK = 'https://creativecommons.org/licenses/by-sa/3.0/'
+ASTEROID_REF = HREF.format('https://github.com/mpariente/asteroid', 'Asteroid')
+
+
+def save_publishable(publish_dir, model_dict, metrics=None, train_conf=None):
+    """ Save models to prepare for publication / model sharing.
+
+    Args:
+        publish_dir (str): Path to the publishing directory.
+            Usually under exp/exp_name/publish_dir
+        model_dict (dict): dict at least with keys `model_args`,
+            `state_dict`,`dataset` or `licenses`
+        metrics (dict): dict with evaluation metrics.
+        train_conf (dict): Training configuration dict (from conf.yml).
+
+    Returns:
+        dict, same as `model_dict` with added fields.
+
+    Raises:
+        AssertionError when either `model_args`, `state_dict`,`dataset` or
+            `licenses` are not present is `model_dict.keys()`
+    """
+    assert 'model_args' in model_dict.keys(), "`model_args` not found in model dict."
+    assert 'state_dict' in model_dict.keys(), "`state_dict` not found in model dict."
+    assert 'dataset' in model_dict.keys(), "`dataset` not found in model dict."
+    assert 'licenses' in model_dict.keys(), "`licenses` not found in model dict."
+    assert isinstance(metrics, dict), "Cannot upload a model without metrics."
+    # Additional infos.
+    recipe_name = next(open(os.path.join(publish_dir, 'recipe_name.txt')))
+    recipe_name.replace('\n', '')  # remove next line
+    model_dict['infos']['recipe_name'] = recipe_name
+    model_dict['infos']['training_config'] = train_conf
+    model_dict['infos']['final_metrics'] = metrics
+    torch.save(model_dict, os.path.join(publish_dir, 'model.pth'))
+    print(PLEASE_PUBLISH.format(publish_dir))
+    return model_dict
+
+
+def upload_publishable(publish_dir, uploader=None, affiliation=None,
+                       git_username=None, token=None, force_publish=False):
+    """ Entry point to upload publishable model.
+
+    Args:
+        publish_dir (str): Path to the publishing directory.
+            Usually under exp/exp_name/publish_dir
+        uploader (str): Full name of the uploader (Ex: Manuel Pariente)
+        affiliation (str, optional): Affiliation (no accent).
+        git_username (str, optional): GitHub username.
+        token (str): Access token generated to upload depositions.
+        force_publish (bool): Whether to directly publish without
+            asking confirmation before. Defaults to False.
+
+    """
+    def get_answer():
+        out = input('\n\nDo you want to publish it now (irreversible)? y/n\n'
+                    'Note: if you dont publish it now, you can publish it '
+                    'online. If you publish it now, you can edit it later. \n')
+        if out not in ['y', 'n']:
+            print(f'\nExpected one of [`y`, `n`], received {out}, please retry.')
+            return get_answer()
+        return out
+
+    if uploader is None:
+        raise ValueError('Need uploader name')
+
+    # Make publishable model and save it
+    model_path = os.path.join(publish_dir, 'model.pth')
+    publish_model_path = os.path.join(publish_dir, 'published_model.pth')
+    model = torch.load(model_path)
+    model = _populate_publishable(
+        model,
+        uploader=uploader,
+        affiliation=affiliation,
+        git_username=git_username,
+    )
+    torch.save(model, publish_model_path)
+
+    # Get Zenodo access token
+    if token is None:
+        token = os.getenv('ACCESS_TOKEN')
+        if token is None:
+            raise ValueError(
+                'Need an access token to Zenodo to upload the model. Either '
+                'set ACCESS_TOKEN environment variable or pass it directly '
+                '(`asteroid-upload --token ...`).'
+                'If you do not have a access token, first create a Zenodo '
+                'account (https://zenodo.org/signup/), create a token '
+                'https://zenodo.org/account/settings/applications/tokens/new/'
+                'and you are all set to help us ! =)'
+            )
+
+    # Do the actual upload
+    zen, dep_id = zenodo_upload(model, token, model_path=publish_model_path)
+    address = os.path.join(zen.zenodo_address, 'deposit', str(dep_id))
+    if force_publish:
+        r_publish = zen.publish_deposition(dep_id)
+        pprint(r_publish.json())
+        print("You can also visit it at {}".format(address))
+        return
+    # Give choice
+    current = zen.get_deposition(dep_id)
+    print(f"\n\n This is the current state of the deposition "
+          f"(see here {address}): ")
+    pprint(current.json())
+    inp = get_answer()
+    if inp == 'y':
+        _ = zen.publish_deposition(dep_id)
+        print("Visit it at {}".format(address))
+    else:
+        print(f'Did not finalize the upload, please visit {address} to finalize it.')
+
+
+def _populate_publishable(model, uploader=None, affiliation=None,
+                          git_username=None):
+    """ Populate infos in publishable model.
+
+    Args:
+        model (dict): Model to publish, with `infos` key, at least.
+        uploader (str): Full name of the uploader (Ex: Manuel Pariente)
+        affiliation (str, optional): Affiliation (no accent).
+        git_username (str, optional): GitHub username.
+
+    Returns:
+        dict (model), same as input `model`
+
+    Notes:
+        If a `git_username` is not specified, we look for it somehow, or take
+        the laptop username.
+    """
+    # Get username somehow
+    if git_username is None:
+        git_username = get_username()
+
+    # Example: mpariente/ConvTasNet_WHAM_sepclean
+    model_name = '_'.join([model['model_name'], model['dataset'],
+                           model['task'].replace('_', '')])
+    upload_name = git_username + '/' + model_name
+    # Write License Notice
+    license_note = make_license_notice(model_name, model['licenses'],
+                                       uploader=uploader)
+    # Add infos
+    model['infos']['uploader'] = uploader
+    model['infos']['git_username'] = git_username
+    model['infos']['affiliation'] = affiliation if affiliation else "Unknown"
+    model['infos']['upload_name'] = upload_name
+    model['infos']['license_note'] = license_note
+    return model
+
+
+def get_username():
+    """ Get git of FS username for upload. """
+    username = subprocess.check_output(["git", "config", "user.name"])
+    username = username.decode('utf-8')[:-1]
+    if not username:  # Empty string
+        import getpass
+        username = getpass.getuser()
+    return username
+
+
+def make_license_notice(model_name, licenses, uploader=None):
+    """ Make license notice based on license dicts.
+
+    Args:
+        model_name (str): Name of the model.
+        licenses (List[dict]): List of dict with
+            keys (`title`, `title_link`, `author`, `author_link`,
+                  `licence`, `licence_link`).
+        uploader (str): Name of the uploader such as "Manuel Pariente".
+
+    Returns:
+        str, the license note describing the model, it's attribution,
+            the original licenses, what we license it under and the licensor.
+    """
+    if uploader is None:
+        raise ValueError("Cannot share model without uploader.")
+    note = "This work \"{}\" is a derivative ".format(model_name)
+    for l_dict in licenses:
+        # Clickable links in HTML.
+        title = HREF.format(l_dict['title_link'], l_dict['title'])
+        author = HREF.format(l_dict['author_link'], l_dict['author'])
+        license_h = HREF.format(l_dict['license_link'], l_dict['license'])
+        comm = " (Research only)" if l_dict['non_commercial'] else ""
+        note += f"of {title} by {author}, used under {license_h}{comm}"
+        note += "; "
+    note = note[:-2] + '. '  # Remove the last ;
+    cc_sa = HREF.format(CC_SA_LINK, CC_SA)
+    note += f"\"{model_name}\" is licensed under {cc_sa} by {uploader}."
+    return note
+
+
+def zenodo_upload(model, token, model_path=None):
+    """ Create deposit and upload metadata + model
+
+    Args:
+        model (dict):
+        token (str): Access token.
+        model_path (str): Saved model path.
+
+    Returns:
+        Zenodo (Zenodo instance with access token)
+        int (deposit ID)
+
+    Notes:
+        If `model_path` is not specified, save the model in tmp.pth and
+        remove it after upload.
+    """
+    model_path_was_none = False
+    if model_path is None:
+        model_path_was_none = True
+        model_path = 'tmp.pth'
+        torch.save(model, model_path)
+        # raise ValueError("Need path")
+
+    zen = Zenodo(token)
+    metadata = make_metadata_from_model(model)
+    r = zen.create_new_deposition(metadata=metadata)
+    dep_id = r.json()["id"]
+    _ = zen.upload_new_file_to_deposition(dep_id, model_path, name='model.pth')
+    if model_path_was_none:
+        os.remove(model_path)
+    return zen, dep_id
+
+
+def make_metadata_from_model(model):
+    """ Create Zenodo deposit metadata for a given publishable model.
+    Args:
+        model (dict): Dictionary with all infos needed to publish.
+            More info to come.
+
+    Returns:
+        dict, the metadata to create the Zenodo deposit with.
+
+    Notes:
+        We remove the PESQ from the final results as a license is needed to
+        use it.
+    """
+    infos = model['infos']
+    # Description section
+    description = '<p><strong>Description: </strong></p>'
+    tmp = 'This model was trained by {} using the {} recipe in {}.'
+    description += tmp.format(infos['uploader'], infos['recipe_name'],
+                              ASTEROID_REF)
+    tmp = '</a>It was trained on the <code>{}</code> task of the {} dataset.</p>'
+    description += tmp.format(model['task'], model['dataset'])
+
+    # Training config section
+    description += '<p>&nbsp;</p>'
+    description += '<p><strong>Training config:</strong></p>'
+    description += two_level_dict_html(infos['training_config'])
+
+    # Results section
+    description += '<p>&nbsp;</p>'
+    description += '<p><strong>Results:</strong></p>'
+    display_result = {
+        k: v for k, v in infos['final_metrics'].items()
+        if 'pesq' not in k.lower()
+    }
+    description += display_one_level_dict(display_result)
+
+    # License section
+    description += '<p>&nbsp;</p>'
+    description += '<p><strong>License notice:</strong></p>'
+    description += infos['license_note']
+
+    # Putting it together.
+    metadata = {
+        'title': infos['upload_name'],
+        'upload_type': 'software',
+        'description': description,
+        'creators': [{'name': infos['uploader'],
+                      'affiliation': infos['affiliation']}],
+        'communities': [{'identifier': 'zenodo'},
+                        {'identifier': 'asteroid-models'}],
+        'keywords': ['Asteroid', 'audio source separation', model['dataset'],
+                     model['task'], model['model_name'], 'pretrained model'],
+        'license': 'other-at'
+    }
+    return metadata
+
+
+def two_level_dict_html(dic):
+    """ Two-level dict to HTML.
+    Args:
+        dic (dict): two-level dict
+
+    Returns:
+        str for HTML-encoded two level dic
+    """
+    html = "<ul>"
+    for k in dic.keys():
+        # Open field
+        html += f'<li>{k}: <ul>'
+        for k2 in dic[k].keys():
+            val = str(dic[k][k2])
+            html += f'<li>{k2}: {val}</li>'
+        # Close field
+        html += '</il></ul>'
+    html += '</ul>'
+    return html
+
+
+def display_one_level_dict(dic):
+    """ Single level dict to HTML
+    Args:
+        dic (dict):
+
+    Returns:
+        str for HTML-encoded single level dic
+    """
+    html = "<ul>"
+    for k in dic.keys():
+        # Open field
+        val = str(dic[k])
+        html += f'<li>{k}: {val} </li>'
+    html += '</ul>'
+    return html

--- a/asteroid/models/publisher.py
+++ b/asteroid/models/publisher.py
@@ -75,9 +75,8 @@ def upload_publishable(publish_dir, uploader=None, affiliation=None,
 
     """
     def get_answer():
-        out = input('\n\nDo you want to publish it now (irreversible)? y/n\n'
-                    'Note: if you dont publish it now, you can publish it '
-                    'online. If you publish it now, you can edit it later. \n')
+        out = input('\n\nDo you want to publish it now (irreversible)? y/n'
+                    '(Recommended: n).\n')
         if out not in ['y', 'n']:
             print(f'\nExpected one of [`y`, `n`], received {out}, please retry.')
             return get_answer()
@@ -131,11 +130,13 @@ def upload_publishable(publish_dir, uploader=None, affiliation=None,
         return zen, current
     else:
         inp = get_answer()
+    # Get user input
     if inp == 'y':
         _ = zen.publish_deposition(dep_id)
         print("Visit it at {}".format(address))
     else:
-        print(f'Did not finalize the upload, please visit {address} to finalize it.')
+        print(f'Did not finalize the upload, please visit {address} to finalize '
+              f'it.')
 
 
 def _populate_publishable(model, uploader=None, affiliation=None,

--- a/asteroid/models/publisher.py
+++ b/asteroid/models/publisher.py
@@ -244,6 +244,10 @@ def zenodo_upload(model, token, model_path=None, use_sandbox=False):
     zen = Zenodo(token, use_sandbox=use_sandbox)
     metadata = make_metadata_from_model(model)
     r = zen.create_new_deposition(metadata=metadata)
+    if r.status_code != 200:
+        print(r.json())
+        raise RuntimeError('Could not create the deposition, check the '
+                           'provided token.')
     dep_id = r.json()["id"]
     _ = zen.upload_new_file_to_deposition(dep_id, model_path, name='model.pth')
     if model_path_was_none:

--- a/asteroid/models/zenodo.py
+++ b/asteroid/models/zenodo.py
@@ -123,7 +123,7 @@ class Zenodo(object):
         print("Zenodo received : {}".format(r.content))
         return r
 
-    def publish_deposition(self, dep_id):
+    def publish_deposition(self, dep_id):  # pragma: no cover (Cannot publish)
         """ Publish given deposition (Cannot be deleted) !
 
         Args:

--- a/asteroid/models/zenodo.py
+++ b/asteroid/models/zenodo.py
@@ -1,0 +1,184 @@
+import os
+import json
+import requests
+from io import BufferedReader, BytesIO
+import torch
+
+
+class Zenodo(object):
+    """ Faciliate Zenodo's REST API.
+
+    Args:
+        api_key (str): Access token generated to upload depositions.
+        use_sandbox (bool): Whether to use the sandbox (default: True)
+            Note that `api_key` are different in sandbox.
+
+    Methods (all methods return the requests response):
+        create_new_deposition
+        change_metadata_in_deposition,
+        upload_new_file_to_deposition
+        publish_deposition
+        get_deposition
+        remove_deposition
+        remove_all_depositions
+
+    Notes:
+        A Zenodo record is something that is public and cannot be deleted.
+        A Zenodo deposit has not yet been published, is private and can be
+        deleted.
+    """
+    def __init__(self, api_key, use_sandbox=True):
+        self.use_sandbox = use_sandbox
+        if use_sandbox is True:
+            self.zenodo_address = 'https://sandbox.zenodo.org'
+        else:
+            self.zenodo_address = 'https://zenodo.org'
+
+        self.api_key = api_key
+        self.auth_header = {'Authorization': f"Bearer {self.api_key}"}
+        self.headers = {"Content-Type": "application/json",
+                        'Authorization': f"Bearer {self.api_key}"}
+
+    def create_new_deposition(self, metadata=None):
+        """ Creates a new deposition.
+
+        Args:
+            metadata (dict, optional): Metadata dict to upload on the new
+                deposition.
+        """
+        r = requests.post(
+            f'{self.zenodo_address}/api/deposit/depositions',
+            json={}, headers=self.headers
+        )
+
+        if r.status_code != 201:
+            print("Creation failed (status code: {})".format(r.status_code))
+            return r
+
+        if metadata is not None and isinstance(metadata, dict):
+            return self.change_metadata_in_deposition(r.json()["id"], metadata)
+        else:
+            print(f"Could not interpret metadata type ({type(metadata)}), "
+                  "expected dict")
+        return r
+
+    def change_metadata_in_deposition(self, dep_id, metadata):
+        """ Set or replace metadata in given deposition
+
+        Args:
+            dep_id (int): deposition id. You cna get it with
+                `r = create_new_deposition(); dep_id = r.json()['id']`
+            metadata (dict): Metadata dict.
+
+        Examples:
+            metadata = {
+                'title': 'My first upload',
+                'upload_type': 'poster',
+                'description': 'This is my first upload',
+                'creators': [{'name': 'Doe, John',
+                              'affiliation': 'Zenodo'}]
+            }
+        """
+        data = {"metadata": metadata}
+        r = requests.put(
+            f'{self.zenodo_address}/api/deposit/depositions/{dep_id}',
+            data=json.dumps(data), headers=self.headers
+        )
+        return r
+
+    def upload_new_file_to_deposition(self, dep_id, file, name=None):
+        """ Upload one file to existing deposition.
+        Args:
+            dep_id (int): deposition id. You cna get it with
+                `r = create_new_deposition(); dep_id = r.json()['id']`
+            file (str or io.BufferedReader): path to a file, or already opened
+                file (path prefered).
+            name (str, optional): name given to the uploaded file.
+                Defaults to the path.
+
+        (More: https://developers.zenodo.org/#deposition-files)
+        """
+        if isinstance(file, BufferedReader):
+            files = {'file': file}
+            filename = name if name else "Unknown"
+        elif isinstance(file, str):
+            if os.path.isfile(file):
+                # This is a file, read it
+                files = {'file': open(os.path.expanduser(file), 'rb')}
+                filename = name if name else os.path.basename(file)
+            else:
+                # This is a string, convert to BytesIO
+                files = {'file': BytesIO(bytes(file, 'utf-8'))}
+                filename = name if name else "Unknown"
+        else:
+            raise ValueError('Unknown file format , expected str or Bytes ')
+        data = {"name": filename}
+        print("Submitting Data: {} and Files: {}".format(data, files))
+
+        r = requests.post(
+            f'{self.zenodo_address}/api/deposit/depositions/{dep_id}/files',
+            headers=self.auth_header, data=data,
+            files=files
+        )
+        print("Zenodo received : {}".format(r.content))
+        return r
+
+    def publish_deposition(self, dep_id):
+        """ Publish given deposition (Cannot be deleted) !
+
+        Args:
+            dep_id (int): deposition id. You cna get it with
+                `r = create_new_deposition(); dep_id = r.json()['id']`
+        """
+        r = requests.post(
+            f'{self.zenodo_address}/api/deposit/depositions/{dep_id}/actions/publish',
+            headers=self.headers
+        )
+        return r
+
+    def get_deposition(self, dep_id=-1):
+        """ Get deposition by deposition id. Get all dep_id is -1 (default)."""
+        if dep_id > -1:
+            print(f"Get deposition {dep_id} from Zenodo")
+            r = requests.get(
+                f"{self.zenodo_address}/api/deposit/depositions/{dep_id}",
+                headers=self.headers
+            )
+        else:
+            print("Get all depositions from Zenodo")
+            r = requests.get(
+                f"{self.zenodo_address}/api/deposit/depositions",
+                headers=self.headers
+            )
+        print("Get Depositions: Status Code: {}".format(r.status_code))
+        return r
+
+    def remove_deposition(self, dep_id):
+        """ Remove deposition with deposition id `dep_id`"""
+        print(f'Delete deposition number {dep_id}')
+        r = requests.delete(
+            f'{self.zenodo_address}/api/deposit/depositions/{dep_id}',
+            headers=self.auth_header
+        )
+        return r
+
+    def remove_all_depositions(self):
+        """ Removes all unpublished deposition (not records)."""
+        all_depositions = self.get_deposition()
+        for dep in all_depositions.json():
+            self.remove_deposition(dep["id"])
+
+
+# Probably remove that.
+# sandbox_asteroid_url = 'https://sandbox.zenodo.org/deposit/new?c=asteroid-models'
+# zenodo_asteroid_url = 'https://zenodo.org/deposit/new?c=asteroid-models'
+class AsteroidZenodo(Zenodo):
+    REQUIRED_KEYS = []
+    def share_model(self, model_path):
+        # Load model_path
+        model = torch.load(model_path)
+        # Assert all keys are there
+        if not all(k in model.keys() for k in self.REQUIRED_KEYS):
+            missing = [k for k in self.REQUIRED_KEYS if k not in model.keys()]
+            raise ValueError(f"Expected all keys {self.REQUIRED_KEYS} but "
+                             f"{missing} were missing.")

--- a/asteroid/scripts/asteroid_cli.py
+++ b/asteroid/scripts/asteroid_cli.py
@@ -1,0 +1,47 @@
+import os
+import yaml
+
+import asteroid
+from asteroid.models.publisher import upload_publishable
+
+
+def upload():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('publish_dir', type=str,
+                        help='Path to the publish dir.')
+    parser.add_argument('--uploader', default=None, type=str,
+                        help='Name of the uploader. Ex: `Manuel Pariente`')
+    parser.add_argument('--affiliation', default=None, type=str,
+                        help='Affiliation of the uploader. Ex `INRIA` ')
+    parser.add_argument('--git_username', default=None, type=str,
+                        help='Username in GitHub')
+    parser.add_argument('--token', default=None, type=str,
+                        help='Access token for Zenodo (or sandbox)')
+    parser.add_argument('--force_publish', default=False, type=bool,
+                        help='Whether to  without asking confirmation')
+    args = parser.parse_args()
+    args_as_dict = dict(vars(args))
+    # Load uploader info if present
+    info_file = os.path.join(asteroid.project_root, 'uploader_info.yml')
+    if os.path.exists(info_file):
+        uploader_info = yaml.safe_load(open(info_file, 'r'))
+        # Replace fields that where not specified (CLI dominates)
+        for k, v in uploader_info.items():
+            if args_as_dict[k] == parser.get_default(k):
+                args_as_dict[k] = v
+    upload_publishable(**args_as_dict)
+    # Suggest creating uploader_infos.yml
+    if not os.path.exists(info_file):
+        example = """
+        ```asteroid/uploader_infos.yml
+        uploader: Manuel Pariente
+        affiliation: Universite Lorraine, CNRS, Inria, LORIA, France
+        git_username: mpariente
+        token: XXX
+        force_upload: n
+        ```
+        """
+        print('You can create a `uploader_infos.yml` file in `Asteroid` root'
+              f'to stop passing your name, affiliation etc. to the CLI. '
+              f'Here is an example {example}')

--- a/asteroid/scripts/asteroid_cli.py
+++ b/asteroid/scripts/asteroid_cli.py
@@ -18,9 +18,9 @@ def upload():
                         help='Username in GitHub')
     parser.add_argument('--token', default=None, type=str,
                         help='Access token for Zenodo (or sandbox)')
-    parser.add_argument('--force_publish', default=False, type=bool,
+    parser.add_argument('--force_publish', default=False, action='store_true',
                         help='Whether to  without asking confirmation')
-    parser.add_argument('--use_sandbox', default=True, type=bool,
+    parser.add_argument('--use_sandbox', default=False, action='store_true',
                         help='Whether to use Zenodo sandbox.')
     args = parser.parse_args()
     args_as_dict = dict(vars(args))
@@ -32,6 +32,7 @@ def upload():
         for k, v in uploader_info.items():
             if args_as_dict[k] == parser.get_default(k):
                 args_as_dict[k] = v
+
     upload_publishable(**args_as_dict)
     # Suggest creating uploader_infos.yml
     if not os.path.exists(info_file):

--- a/asteroid/scripts/asteroid_cli.py
+++ b/asteroid/scripts/asteroid_cli.py
@@ -20,6 +20,8 @@ def upload():
                         help='Access token for Zenodo (or sandbox)')
     parser.add_argument('--force_publish', default=False, type=bool,
                         help='Whether to  without asking confirmation')
+    parser.add_argument('--use_sandbox', default=True, type=bool,
+                        help='Whether to use Zenodo sandbox.')
     args = parser.parse_args()
     args_as_dict = dict(vars(args))
     # Load uploader info if present

--- a/egs/wham/ConvTasNet/eval.py
+++ b/egs/wham/ConvTasNet/eval.py
@@ -6,14 +6,15 @@ import yaml
 import json
 import argparse
 import pandas as pd
-from asteroid.metrics import get_metrics
 from tqdm import tqdm
 from pprint import pprint
 
+from asteroid.metrics import get_metrics
 from asteroid.losses import PITLossWrapper, pairwise_neg_sisdr
 from asteroid.data.wham_dataset import WhamDataset
 from asteroid.models import ConvTasNet
 from asteroid.utils import tensors_to_device
+from asteroid.models import save_publishable
 
 
 parser = argparse.ArgumentParser()
@@ -99,6 +100,12 @@ def main(conf):
     pprint(final_results)
     with open(os.path.join(conf['exp_dir'], 'final_metrics.json'), 'w') as f:
         json.dump(final_results, f, indent=0)
+
+    model_dict = torch.load(model_path, map_location='cpu')
+    publishable = save_publishable(
+        os.path.join(conf['exp_dir'], 'publish_dir'), model_dict,
+        metrics=final_results, train_conf=train_conf
+    )
 
 
 if __name__ == '__main__':

--- a/egs/wham/ConvTasNet/eval.py
+++ b/egs/wham/ConvTasNet/eval.py
@@ -12,9 +12,9 @@ from pprint import pprint
 
 from asteroid.losses import PITLossWrapper, pairwise_neg_sisdr
 from asteroid.data.wham_dataset import WhamDataset
+from asteroid.models import ConvTasNet
 from asteroid.utils import tensors_to_device
 
-from model import load_best_model
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--task', type=str, required=True,
@@ -33,7 +33,8 @@ compute_metrics = ['si_sdr', 'sdr', 'sir', 'sar', 'stoi']
 
 
 def main(conf):
-    model = load_best_model(conf['train_conf'], conf['exp_dir'])
+    model_path = os.path.join(conf['exp_dir'], 'best_model.pth')
+    model = ConvTasNet.from_pretrained(model_path)
     # Handle device placement
     if conf['use_gpu']:
         model.cuda()

--- a/egs/wham/ConvTasNet/run.sh
+++ b/egs/wham/ConvTasNet/run.sh
@@ -108,6 +108,10 @@ if [[ $stage -le 3 ]]; then
 		--n_repeats $n_repeats \
 		--exp_dir ${expdir}/ | tee logs/train_${tag}.log
 	cp logs/train_${tag}.log $expdir/train.log
+
+	# Get ready to publish
+	mkdir -p $expdir/publish_dir
+	echo "wham/ConvTasNet" > $expdir/publish_dir/recipe_name.txt
 fi
 
 if [[ $stage -le 4 ]]; then

--- a/egs/wham/ConvTasNet/train.py
+++ b/egs/wham/ConvTasNet/train.py
@@ -88,7 +88,7 @@ def main(conf):
                          gpus=conf['main_args']['gpus'],
                          distributed_backend='dp',
                          train_percent_check=1.0,  # Useful for fast experiment
-                         gradient_clip_val=5., fast_dev_run=True)
+                         gradient_clip_val=5.)
     trainer.fit(system)
 
     best_k = {k: v.item() for k, v in checkpoint.best_k_models.items()}

--- a/egs/wham/ConvTasNet/train.py
+++ b/egs/wham/ConvTasNet/train.py
@@ -9,10 +9,10 @@ import pytorch_lightning as pl
 from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping
 
 from asteroid.data.wham_dataset import WhamDataset
+from asteroid.engine.optimizers import make_optimizer
 from asteroid.engine.system import System
 from asteroid.losses import PITLossWrapper, pairwise_neg_sisdr
-
-from model import make_model_and_optimizer
+from asteroid.models import ConvTasNet
 
 
 # Keys which are not in the conf.yml file can be added here.
@@ -47,10 +47,9 @@ def main(conf):
     # Update number of source values (It depends on the task)
     conf['masknet'].update({'n_src': train_set.n_src})
 
-    # Define model and optimizer in a local function (defined in the recipe).
-    # Two advantages to this : re-instantiating the model and optimizer
-    # for retraining and evaluating is straight-forward.
-    model, optimizer = make_model_and_optimizer(conf)
+    # Define model and optimizer
+    model = ConvTasNet(**conf['filterbank'], **conf['masknet'])
+    optimizer = make_optimizer(model.parameters(), **conf['optim'])
     # Define scheduler
     scheduler = None
     if conf['training']['half_lr']:
@@ -89,12 +88,20 @@ def main(conf):
                          gpus=conf['main_args']['gpus'],
                          distributed_backend='dp',
                          train_percent_check=1.0,  # Useful for fast experiment
-                         gradient_clip_val=5.)
+                         gradient_clip_val=5., fast_dev_run=True)
     trainer.fit(system)
 
     best_k = {k: v.item() for k, v in checkpoint.best_k_models.items()}
     with open(os.path.join(exp_dir, "best_k_models.json"), "w") as f:
         json.dump(best_k, f, indent=0)
+
+    # Save best model
+    best_path = [b for b, v in best_k.items() if v == min(best_k.values())][0]
+    state_dict = torch.load(best_path)
+    system.load_state_dict(state_dict=state_dict['state_dict'])
+    system.cpu()
+    torch.save(system.model.serialize(),
+               os.path.join(exp_dir, 'best_model.pth'))
 
 
 if __name__ == '__main__':

--- a/egs/wham/ConvTasNet/train.py
+++ b/egs/wham/ConvTasNet/train.py
@@ -95,13 +95,15 @@ def main(conf):
     with open(os.path.join(exp_dir, "best_k_models.json"), "w") as f:
         json.dump(best_k, f, indent=0)
 
-    # Save best model
+    # Save best model (next PL version will make this easier)
     best_path = [b for b, v in best_k.items() if v == min(best_k.values())][0]
     state_dict = torch.load(best_path)
     system.load_state_dict(state_dict=state_dict['state_dict'])
     system.cpu()
-    torch.save(system.model.serialize(),
-               os.path.join(exp_dir, 'best_model.pth'))
+
+    to_save = system.model.serialize()
+    to_save.update(train_set.get_infos())
+    torch.save(to_save, os.path.join(exp_dir, 'best_model.pth'))
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ setup(
         'visualize': ['seaborn'],
         'tests': ['pytest'],
     },
+    entry_points={
+        'console_scripts': ['asteroid-upload=asteroid.scripts.asteroid_cli:upload'],
+    },
     packages=find_packages(),
     include_package_data=True,
     classifiers=[

--- a/tests/models/publish_test.py
+++ b/tests/models/publish_test.py
@@ -1,0 +1,42 @@
+import os
+import json
+import shutil
+
+from asteroid.models import save_publishable, upload_publishable, ConvTasNet
+from asteroid.data import WhamDataset
+
+
+def populate_wham_dir(path):
+    wham_files = ['s1', 's2', 'noise', 'mix_single', 'mix_clean', 'mix_both']
+    os.makedirs(path, exist_ok=True)
+    for source in wham_files:
+        json_file = os.path.join(path, source + '.json')
+        with open(os.path.join(json_file), 'w') as f:
+            json.dump(dict(), f)
+
+
+def test_upload():
+    # Make dirs
+    os.makedirs('tmp/publish_dir', exist_ok=True)
+    populate_wham_dir('tmp/wham')
+
+    # Dataset and NN
+    train_set = WhamDataset('tmp/wham', task='sep_clean')
+    model = ConvTasNet(n_src=2, n_repeats=2, n_blocks=2, bn_chan=16,
+                       hid_chan=4, skip_chan=8, n_filters=32)
+
+    # Save publishable
+    model_conf = model.serialize()
+    model_conf.update(train_set.get_infos())
+    save_publishable('tmp/publish_dir', model_conf, metrics={}, train_conf={})
+
+    # Upload and delete
+    zen, current = upload_publishable(
+        'tmp/publish_dir',
+        uploader="Manuel Pariente",
+        affiliation="INRIA",
+        use_sandbox=True,
+        unit_test=True,  # Remove this argument and monkeypatch `input()`
+    )
+    zen.remove_deposition(current.json()['id'])
+    shutil.rmtree('tmp/wham')

--- a/tests/models/publish_test.py
+++ b/tests/models/publish_test.py
@@ -30,7 +30,7 @@ def test_upload():
     model_conf.update(train_set.get_infos())
     save_publishable('tmp/publish_dir', model_conf, metrics={}, train_conf={})
 
-    # Upload and delete
+    # Upload
     zen, current = upload_publishable(
         'tmp/publish_dir',
         uploader="Manuel Pariente",
@@ -38,5 +38,17 @@ def test_upload():
         use_sandbox=True,
         unit_test=True,  # Remove this argument and monkeypatch `input()`
     )
+
+    # Assert metadata is correct
+    meta = current.json()['metadata']
+    assert meta['creators'][0]['name'] == "Manuel Pariente"
+    assert meta['creators'][0]['affiliation'] == "INRIA"
+    assert 'asteroid-models' in [d['identifier'] for d in meta['communities']]
+
+    # Clean up
     zen.remove_deposition(current.json()['id'])
     shutil.rmtree('tmp/wham')
+
+
+if __name__ == '__main__':
+    test_upload()


### PR DESCRIPTION
### :rocket:  New features :rocket: 
- We opened a asteroid-models community both [in Zenodo](https://zenodo.org/communities/asteroid-models) and [Zenodo's sandbox](https://sandbox.zenodo.org/communities/asteroid-models).
- New Zenodo interface (I prefered writing this instead of depending on yet another third party lib)
- New CLI `asteroid-upload` to upload pretrained models directly to the Zenodo community. 

### What's left to do 
- Tests & docs
- Same for other ConvTasNet recipes
- Same for DPRNN recipes
- Add other architectures in `asteroid.models`
- Handle the loading from Hub (should be easy).
- Licenses and infos on the other datasets.

### More about the CLI
The CLI is made with and `entry-point` in the setup.py so it is installed with pip and accessible everywhere.
[This record](https://sandbox.zenodo.org/record/578753#.Xs7leBZ8JC0) (in sandbox) is an example of deposit which was made only by CLI with this command
```bash
asteroid-upload exp/train_convtasnet/publish_dir --uploader "Manuel Pariente" --affiliation "INRIA"
```
The text is auto-generated as well as the attribution in the Licenses etc.. 

Instead of specifying the uploader and affiliation every time in the CLI, the user can create a `uploader_infos.yml` in the package root 
```yaml
uploader: Manuel Pariente
affiliation: INRIA
git_username: mpariente
token: XXX
force_upload: n
```
and the usage becomes `asteroid-upload publish_dir`

### Don't forget
- Zenodo is still in `sandbox` mode by default, we'll need to change that (and provide an arg in the CLI)

Tagging #53 