### PR TITLE
[src&tests] Pretrained model loading

### DIFF
--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from .. import torch_utils
 from .. import __version__ as asteroid_version
+from ..utils.hub_utils import cached_download
 
 
 class BaseTasNet(nn.Module):
@@ -103,7 +104,8 @@ class BaseTasNet(nn.Module):
                 `model_args` and `state_dict`.
         """
         if isinstance(pretrained_model_conf_or_path, str):
-            conf = torch.load(pretrained_model_conf_or_path, map_location='cpu')
+            cached_model = cached_download(pretrained_model_conf_or_path)
+            conf = torch.load(cached_model, map_location='cpu')
         else:
             conf = pretrained_model_conf_or_path
         if 'model_args' not in conf.keys():

--- a/asteroid/utils/hub_utils.py
+++ b/asteroid/utils/hub_utils.py
@@ -1,0 +1,55 @@
+import os
+from torch import hub
+from hashlib import sha256
+
+
+CACHE_DIR = os.getenv(
+    'ASTEROID_CACHE',
+    os.path.expanduser('~/.cache/torch/asteroid'),
+)
+MODELS_URLS_HASHTABLE = {
+    'mpariente/ConvTasNet_WHAM!_sepclean': 'https://zenodo.org/record/3862942/files/model.pth?download=1',
+}
+
+
+def cached_download(filename_or_url):
+    """ Download from URL with torch.hub and cache the result in ASTEROID_CACHE.
+
+    Args:
+        filename_or_url (str): Name of a model as named on the Zenodo Community
+            page (ex: mpariente/ConvTasNet_WHAM!_sepclean), or an URL to a model
+            file (ex: https://zenodo.org/.../model.pth), or a filename
+            that exists locally (ex: local/tmp_model.pth)
+
+    Returns:
+        str, normalized path to the downloaded (or not) model
+    """
+    if os.path.isfile(filename_or_url):
+        return filename_or_url
+
+    if filename_or_url in MODELS_URLS_HASHTABLE:
+        url = MODELS_URLS_HASHTABLE[filename_or_url]
+    else:
+        # Give a chance to direct URL, torch.hub will handle exceptions
+        url = filename_or_url
+    cached_filename = url_to_filename(url)
+    cached_path = os.path.join(get_cache_dir(), cached_filename, 'model.pth')
+    if not os.path.isfile(cached_path):
+        hub.download_url_to_file(url, cached_path)
+        return cached_path
+    # It was already downloaded
+    print(f'Using cached model `{filename_or_url}`')
+    return cached_path
+
+
+def url_to_filename(url):
+    """ Consistently convert `url` into a filename. """
+    _bytes = url.encode("utf-8")
+    _hash = sha256(_bytes)
+    filename = _hash.hexdigest()
+    return filename
+
+
+def get_cache_dir():
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    return CACHE_DIR


### PR DESCRIPTION
`from_pretrained` supports three types of input:
- filename: 'tmp/model.path'
- Zenodo model name: 'mpariente/ConvTasNetWHAM!...' (find in community)
- Simple URL from Zenodo

We keep a hashtable with all the name: URL mappings for simplicity.
In both last cases, the models are downloaded and cached in `ASTEROID_CACHE` env variable (defaults to '~/.cache/torch/asteroid').

Loading in two lines works
```python
from asteroid.models import ConvTasNet
model = ConvTasNet.from_pretrained('mpariente/ConvTasNet_WHAM!_sepclean')
```

Loading from hub as well.
```python
model = torch.hub.load('mpariente/asteroid:load_pretrained', 'conv_tasnet', 'mpariente/ConvTasNet_WHAM!_sepclean') 
```

Tagging #53 