### PR TITLE
[egs] GPU `id` defaults to $CUDA_VISIBLE_DEVICES in all recipes

### DIFF
--- a/egs/dns_challenge/baseline/run.sh
+++ b/egs/dns_challenge/baseline/run.sh
@@ -16,7 +16,7 @@ python_path=python
 stage=0
 tag=""  # Controls the directory name associated to the experiment
 # You can ask for several GPUs using id (passed to CUDA_VISIBLE_DEVICES)
-id=
+id=$CUDA_VISIBLE_DEVICES
 
 # Experiment config
 is_complex=1  # If we use a complex network for training.

--- a/egs/fuss/baseline/run.sh
+++ b/egs/fuss/baseline/run.sh
@@ -30,7 +30,7 @@ python_path=python
 stage=0  # Controls from which stage to start
 tag=""  # Controls the directory name associated to the experiment
 # You can ask for several GPUs using id (passed to CUDA_VISIBLE_DEVICES)
-id=
+id=$CUDA_VISIBLE_DEVICES
 
 
 # Data

--- a/egs/librimix/ConvTasNet/run.sh
+++ b/egs/librimix/ConvTasNet/run.sh
@@ -19,7 +19,7 @@ python_path=python
 stage=0  # Controls from which stage to start
 tag=""  # Controls the directory name associated to the experiment
 # You can ask for several GPUs using id (passed to CUDA_VISIBLE_DEVICES)
-id=
+id=$CUDA_VISIBLE_DEVICES
 out_dir=librimix # Controls the directory name associated to the evaluation results inside the experiment directory
 
 # Network config

--- a/egs/wham/ConvTasNet/run.sh
+++ b/egs/wham/ConvTasNet/run.sh
@@ -24,7 +24,7 @@ python_path=python
 stage=0  # Controls from which stage to start
 tag=""  # Controls the directory name associated to the experiment
 # You can ask for several GPUs using id (passed to CUDA_VISIBLE_DEVICES)
-id=
+id=$CUDA_VISIBLE_DEVICES
 
 # Data
 task=sep_clean  # Specify the task here (sep_clean, sep_noisy, enh_single, enh_both)

--- a/egs/wham/DPRNN/run.sh
+++ b/egs/wham/DPRNN/run.sh
@@ -24,7 +24,7 @@ python_path=python
 stage=3  # Controls from which stage to start
 tag=""  # Controls the directory name associated to the experiment
 # You can ask for several GPUs using id (passed to CUDA_VISIBLE_DEVICES)
-id=0
+id=$CUDA_VISIBLE_DEVICES
 
 # Data
 task=sep_clean  # Specify the task here (sep_clean, sep_noisy, enh_single, enh_both)

--- a/egs/wham/DynamicMixing/run.sh
+++ b/egs/wham/DynamicMixing/run.sh
@@ -30,7 +30,7 @@ python_path=python
 stage=3  # Controls from which stage to start
 tag=""  # Controls the directory name associated to the experiment
 # You can ask for several GPUs using id (passed to CUDA_VISIBLE_DEVICES)
-id=0
+id=$CUDA_VISIBLE_DEVICES
 
 # Data
 data_dir=data  # Local data directory (No disk space needed)

--- a/egs/wham/TwoStep/run.sh
+++ b/egs/wham/TwoStep/run.sh
@@ -24,7 +24,7 @@ python_path=python
 stage=0  # Controls from which stage to start
 tag=""  # Controls the directory name associated to the experiment
 # You can ask for several GPUs using id (passed to CUDA_VISIBLE_DEVICES)
-id=
+id=$CUDA_VISIBLE_DEVICES
 
 # Data
 data_dir=data  # Local data directory (No disk space needed)

--- a/egs/whamr/TasNet/run.sh
+++ b/egs/whamr/TasNet/run.sh
@@ -24,7 +24,7 @@ python_path=python
 stage=0  # Controls from which stage to start
 tag=""  # Controls the directory name associated to the experiment
 # You can ask for several GPUs using id (passed to CUDA_VISIBLE_DEVICES)
-id=
+id=$CUDA_VISIBLE_DEVICES
 
 # Data
 task=sep_clean  # Specify the task here (sep_clean, sep_noisy, sep_reverb, sep_reverb_noisy)

--- a/egs/wsj0-mix/DeepClustering/run.sh
+++ b/egs/wsj0-mix/DeepClustering/run.sh
@@ -25,7 +25,7 @@ python_path=python
 stage=3  # Controls from which stage to start
 tag=""  # Controls the directory name associated to the experiment
 # You can ask for several GPUs using id (passed to CUDA_VISIBLE_DEVICES)
-id=
+id=$CUDA_VISIBLE_DEVICES
 
 # Data
 #data_dir=data  # Local data directory (No disk space needed)


### PR DESCRIPTION
We've had feedback and this is the most common usecase so far

`find . -iname run.sh -exec sed -E -i 's/id=.?$/id=\$CUDA_VISIBLE_DEVICES/g' {} +`