### PR TITLE
Add License info on all supported datasets

### DIFF
--- a/asteroid/data/dns_dataset.py
+++ b/asteroid/data/dns_dataset.py
@@ -34,3 +34,26 @@ class DNSDataset(data.Dataset):
         noise = torch.from_numpy(sf.read(utt_info['noise'],
                                          dtype='float32')[0])
         return x, speech, noise
+
+    def get_infos(self):
+        """ Get dataset infos (for publishing models).
+
+        Returns:
+            dict, dataset infos with keys `dataset`, `task` and `licences`.
+        """
+        infos = dict()
+        infos['dataset'] = self.dataset_name
+        infos['task'] = 'enhancement'
+        infos['licenses'] = [dns_license]
+        return infos
+
+
+dns_license = dict(
+    title='Deep Noise Suppression (DNS) Challenge',
+    title_link='https://github.com/microsoft/DNS-Challenge',
+    author='Microsoft',
+    author_link='https://www.microsoft.com/fr-fr/',
+    license='CC BY-NC 4.0',
+    license_link='https://creativecommons.org/licenses/by-nc/4.0/',
+    non_commercial=False,
+)

--- a/asteroid/data/librimix_dataset.py
+++ b/asteroid/data/librimix_dataset.py
@@ -127,8 +127,8 @@ class LibriMix(Dataset):
 librispeech_license = dict(
     title='LibriSpeech ASR corpus',
     title_link='http://www.openslr.org/12',
-    author='Open SLR',
-    author_link='http://www.openslr.org/',
+    author='Vassil Panayotov',
+    author_link='https://github.com/vdp',
     license='CC BY 4.0',
     license_link='https://creativecommons.org/licenses/by/4.0/',
     non_commercial=False

--- a/asteroid/data/librimix_dataset.py
+++ b/asteroid/data/librimix_dataset.py
@@ -5,6 +5,7 @@ import torch
 from torch.utils.data.dataset import Dataset
 import random as random
 import os
+from .wham_dataset import wham_noise_license
 
 
 class LibriMix(Dataset):
@@ -101,3 +102,34 @@ class LibriMix(Dataset):
         # Convert sources to tensor
         sources = torch.from_numpy(sources)
         return mixture, sources
+
+    def get_infos(self):
+        """ Get dataset infos (for publishing models).
+
+        Returns:
+            dict, dataset infos with keys `dataset`, `task` and `licences`.
+        """
+        infos = dict()
+        infos['dataset'] = self._dataset_name()
+        infos['task'] = self.task
+        if self.task == 'sep_clean':
+            data_license = [librispeech_license]
+        else:
+            data_license = [librispeech_license, wham_noise_license]
+        infos['licenses'] = data_license
+        return infos
+
+    def _dataset_name(self):
+        """ Differentiate between 2 and 3 sources."""
+        return f'Libri{self.task}Mix'
+
+
+librispeech_license = dict(
+    title='LibriSpeech ASR corpus',
+    title_link='http://www.openslr.org/12',
+    author='Open SLR',
+    author_link='http://www.openslr.org/',
+    license='CC BY 4.0',
+    license_link='https://creativecommons.org/licenses/by/4.0/',
+    non_commercial=False
+)

--- a/asteroid/data/musdb18_dataset.py
+++ b/asteroid/data/musdb18_dataset.py
@@ -213,3 +213,26 @@ class MUSDB18Dataset(torch.utils.data.Dataset):
                         'path': track_path,
                         'min_duration': None
                     })
+
+    def get_infos(self):
+        """ Get dataset infos (for publishing models).
+
+        Returns:
+            dict, dataset infos with keys `dataset`, `task` and `licences`.
+        """
+        infos = dict()
+        infos['dataset'] = self.dataset_name
+        infos['task'] = 'enhancement'
+        infos['licenses'] = [musdb_license]
+        return infos
+
+
+musdb_license = dict(
+    title='MUSDB18',
+    title_link='https://sigsep.github.io/datasets/musdb.html',
+    author='SigSep',
+    author_link='',
+    license='CC BY-NC-SA 4.0',
+    license_link='https://creativecommons.org/licenses/by-nc-sa/4.0/',
+    non_commercial=True,
+)

--- a/asteroid/data/musdb18_dataset.py
+++ b/asteroid/data/musdb18_dataset.py
@@ -228,11 +228,4 @@ class MUSDB18Dataset(torch.utils.data.Dataset):
 
 
 musdb_license = dict(
-    title='MUSDB18',
-    title_link='https://sigsep.github.io/datasets/musdb.html',
-    author='SigSep',
-    author_link='',
-    license='CC BY-NC-SA 4.0',
-    license_link='https://creativecommons.org/licenses/by-nc-sa/4.0/',
-    non_commercial=True,
 )

--- a/asteroid/data/wham_dataset.py
+++ b/asteroid/data/wham_dataset.py
@@ -4,6 +4,7 @@ import json
 import os
 import numpy as np
 import soundfile as sf
+from .wsj0_mix import wsj0_license
 EPS = 1e-8
 
 DATASET = 'WHAM'
@@ -183,16 +184,6 @@ class WhamDataset(data.Dataset):
         infos['licenses'] = data_license
         return infos
 
-
-wsj0_license = dict(
-    title='CSR-I (WSJ0) Complete',
-    title_link='https://catalog.ldc.upenn.edu/LDC93S6A',
-    author='LDC',
-    author_link='https://www.ldc.upenn.edu/',
-    license='LDC User Agreement for Non-Members',
-    license_link='https://catalog.ldc.upenn.edu/license/ldc-non-members-agreement.pdf',
-    non_commercial=True
-)
 
 wham_noise_license = dict(
     title='The WSJ0 Hipster Ambient Mixtures dataset',

--- a/asteroid/data/whamr_dataset.py
+++ b/asteroid/data/whamr_dataset.py
@@ -4,6 +4,8 @@ import json
 import os
 import numpy as np
 import soundfile as sf
+from .wsj0_mix import wsj0_license
+from .wham_dataset import wham_noise_license
 
 DATASET = 'WHAMR'
 
@@ -155,3 +157,19 @@ class WhamRDataset(data.Dataset):
             source_arrays.append(s)
         sources = torch.from_numpy(np.vstack(source_arrays))
         return torch.from_numpy(x), sources
+
+    def get_infos(self):
+        """ Get dataset infos (for publishing models).
+
+        Returns:
+            dict, dataset infos with keys `dataset`, `task` and `licences`.
+        """
+        infos = dict()
+        infos['dataset'] = self.dataset_name
+        infos['task'] = self.task
+        if self.task == 'sep_clean':
+            data_license = [wsj0_license]
+        else:
+            data_license = [wsj0_license, wham_noise_license]
+        infos['licenses'] = data_license
+        return infos

--- a/asteroid/data/wsj0_mix.py
+++ b/asteroid/data/wsj0_mix.py
@@ -101,3 +101,26 @@ class Wsj0mixDataset(data.Dataset):
             source_arrays.append(s)
         sources = torch.from_numpy(np.vstack(source_arrays))
         return torch.from_numpy(x), sources
+
+    def get_infos(self):
+        """ Get dataset infos (for publishing models).
+
+        Returns:
+            dict, dataset infos with keys `dataset`, `task` and `licences`.
+        """
+        infos = dict()
+        infos['dataset'] = self.dataset_name
+        infos['task'] = 'sep_clean'
+        infos['licenses'] = [wsj0_license]
+        return infos
+
+
+wsj0_license = dict(
+    title='CSR-I (WSJ0) Complete',
+    title_link='https://catalog.ldc.upenn.edu/LDC93S6A',
+    author='LDC',
+    author_link='https://www.ldc.upenn.edu/',
+    license='LDC User Agreement for Non-Members',
+    license_link='https://catalog.ldc.upenn.edu/license/ldc-non-members-agreement.pdf',
+    non_commercial=True
+)


### PR DESCRIPTION
I'm going to ask the owners of the License / creators of the dataset to approve the License infos, directly in the code. Sorry for pinging.

These license info will be used to automatically generate the Attribution statement in the license of pretrained models.