### PR TITLE
[egs] Remove gpus args in all train.py. 

### DIFF
--- a/egs/dns_challenge/baseline/train.py
+++ b/egs/dns_challenge/baseline/train.py
@@ -16,7 +16,6 @@ from model import make_model_and_optimizer, SimpleSystem, distance
 torch.manual_seed(17)  # Reproducibility on the dataset spliting
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--gpus', type=str, help='list of GPUs', default='-1')
 parser.add_argument('--exp_dir', default='exp/tmp',
                     help='Full path to save best validation model')
 parser.add_argument('--is_complex', default=True, type=str2bool_arg)
@@ -69,15 +68,12 @@ def main(conf):
                                        verbose=1)
 
     # Don't ask GPU if they are not available.
-    if not torch.cuda.is_available():
-        print('No available GPU were found, set gpus to None')
-        conf['main_args']['gpus'] = None
-
+    gpus = -1 if torch.cuda.is_available() else None
     trainer = pl.Trainer(max_nb_epochs=conf['training']['epochs'],
                          checkpoint_callback=checkpoint,
                          early_stop_callback=early_stopping,
                          default_save_path=exp_dir,
-                         gpus=conf['main_args']['gpus'],
+                         gpus=gpus,
                          distributed_backend='dp',
                          train_percent_check=1.0,  # Useful for fast experiment
                          gradient_clip_val=5.,)

--- a/egs/librimix/ConvTasNet/train.py
+++ b/egs/librimix/ConvTasNet/train.py
@@ -19,9 +19,7 @@ from model import make_model_and_optimizer
 
 # By default train.py will use all available GPUs. The `id` option in run.sh
 # will limit the number of available GPUs for train.py .
-# This can be changed: `python train.py --gpus 0,1` will only train on 2 GPUs.
 parser = argparse.ArgumentParser()
-parser.add_argument('--gpus', type=str, help='list of GPUs', default='-1')
 parser.add_argument('--exp_dir', default='exp/tmp',
                     help='Full path to save best validation model')
 
@@ -82,14 +80,12 @@ def main(conf):
                                        verbose=1)
 
     # Don't ask GPU if they are not available.
-    if not torch.cuda.is_available():
-        print('No available GPU were found, set gpus to None')
-        conf['main_args']['gpus'] = None
+    gpus = -1 if torch.cuda.is_available() else None
     trainer = pl.Trainer(max_epochs=conf['training']['epochs'],
                          checkpoint_callback=checkpoint,
                          early_stop_callback=early_stopping,
                          default_save_path=exp_dir,
-                         gpus=conf['main_args']['gpus'],
+                         gpus=gpus,
                          distributed_backend='dp',
                          train_percent_check=1.0,  # Useful for fast experiment
                          gradient_clip_val=5.)

--- a/egs/wham/ConvTasNet/train.py
+++ b/egs/wham/ConvTasNet/train.py
@@ -21,9 +21,7 @@ from asteroid.models import ConvTasNet
 
 # By default train.py will use all available GPUs. The `id` option in run.sh
 # will limit the number of available GPUs for train.py .
-# This can be changed: `python train.py --gpus 0,1` will only train on 2 GPUs.
 parser = argparse.ArgumentParser()
-parser.add_argument('--gpus', type=str, help='list of GPUs', default='-1')
 parser.add_argument('--exp_dir', default='exp/tmp',
                     help='Full path to save best validation model')
 
@@ -78,14 +76,12 @@ def main(conf):
                                        verbose=1)
 
     # Don't ask GPU if they are not available.
-    if not torch.cuda.is_available():
-        print('No available GPU were found, set gpus to None')
-        conf['main_args']['gpus'] = None
+    gpus = -1 if torch.cuda.is_available() else None
     trainer = pl.Trainer(max_epochs=conf['training']['epochs'],
                          checkpoint_callback=checkpoint,
                          early_stop_callback=early_stopping,
                          default_save_path=exp_dir,
-                         gpus=conf['main_args']['gpus'],
+                         gpus=gpus,
                          distributed_backend='dp',
                          train_percent_check=1.0,  # Useful for fast experiment
                          gradient_clip_val=5.)

--- a/egs/wham/DPRNN/train.py
+++ b/egs/wham/DPRNN/train.py
@@ -21,9 +21,7 @@ from model import make_model_and_optimizer
 
 # By default train.py will use all available GPUs. The `id` option in run.sh
 # will limit the number of available GPUs for train.py .
-# This can be changed: `python train.py --gpus 0,1` will only train on 2 GPUs.
 parser = argparse.ArgumentParser()
-parser.add_argument('--gpus', type=str, help='list of GPUs', default='-1')
 parser.add_argument('--exp_dir', default='exp/tmp',
                     help='Full path to save best validation model')
 
@@ -79,14 +77,12 @@ def main(conf):
                                        verbose=1)
 
     # Don't ask GPU if they are not available.
-    if not torch.cuda.is_available():
-        print('No available GPU were found, set gpus to None')
-        conf['main_args']['gpus'] = None
+    gpus = -1 if torch.cuda.is_available() else None
     trainer = pl.Trainer(max_nb_epochs=conf['training']['epochs'],
                          checkpoint_callback=checkpoint,
                          early_stop_callback=early_stopping,
                          default_save_path=exp_dir,
-                         gpus=conf['main_args']['gpus'],
+                         gpus=gpus,
                          distributed_backend='ddp',
                          gradient_clip_val=conf['training']["gradient_clipping"])
     trainer.fit(system)

--- a/egs/wham/DynamicMixing/train.py
+++ b/egs/wham/DynamicMixing/train.py
@@ -22,9 +22,7 @@ from model import make_model_and_optimizer
 
 # By default train.py will use all available GPUs. The `id` option in run.sh
 # will limit the number of available GPUs for train.py .
-# This can be changed: `python train.py --gpus 0,1` will only train on 2 GPUs.
 parser = argparse.ArgumentParser()
-parser.add_argument('--gpus', type=str, help='list of GPUs', default='-1')
 parser.add_argument('--exp_dir', default='exp/tmp',
                     help='Full path to save best validation model')
 
@@ -88,14 +86,12 @@ def main(conf):
                                        verbose=1)
 
     # Don't ask GPU if they are not available.
-    if not torch.cuda.is_available():
-        print('No available GPU were found, set gpus to None')
-        conf['main_args']['gpus'] = None
+    gpus = -1 if torch.cuda.is_available() else None
     trainer = pl.Trainer(max_nb_epochs=conf['training']['epochs'],
                          checkpoint_callback=checkpoint,
                          early_stop_callback=early_stopping,
                          default_save_path=exp_dir,
-                         gpus=conf['main_args']['gpus'],
+                         gpus=gpus,
                          distributed_backend='dp',
                          gradient_clip_val=conf['training']["gradient_clipping"])
     trainer.fit(system)

--- a/egs/wham/TwoStep/train.py
+++ b/egs/wham/TwoStep/train.py
@@ -22,9 +22,7 @@ from model import make_model_and_optimizer
 
 # By default train.py will use all available GPUs. The `id` option in run.sh
 # will limit the number of available GPUs for train.py .
-# This can be changed: `python train.py --gpus 0,1` will only train on 2 GPUs.
 parser = argparse.ArgumentParser()
-parser.add_argument('--gpus', type=str, help='list of GPUs', default='-1')
 parser.add_argument('--exp_dir', default='exp/model_logs',
                     help='Full path to save best validation model')
 
@@ -96,16 +94,13 @@ def train_model_part(conf, train_part='filterbank', pretrained_filterbank=None):
         early_stopping = EarlyStopping(monitor='val_loss', patience=10,
                                        verbose=1)
     # Don't ask GPU if they are not available.
-    if not torch.cuda.is_available():
-        print('No available GPU were found, set gpus to None')
-        conf['main_args']['gpus'] = None
-
+    gpus = -1 if torch.cuda.is_available() else None
     trainer = pl.Trainer(
         max_nb_epochs=conf[train_part + '_training'][train_part[0] + '_epochs'],
         checkpoint_callback=checkpoint,
         early_stop_callback=early_stopping,
         default_save_path=exp_dir,
-        gpus=conf['main_args']['gpus'],
+        gpus=gpus,
         distributed_backend='dp',
         train_percent_check=1.0,  # Useful for fast experiment
         gradient_clip_val=5.)

--- a/egs/whamr/TasNet/train.py
+++ b/egs/whamr/TasNet/train.py
@@ -21,9 +21,7 @@ warnings.simplefilter("ignore", UserWarning)
 
 # By default train.py will use all available GPUs. The `id` option in run.sh
 # will limit the number of available GPUs for train.py .
-# This can be changed: `python train.py --gpus 0,1` will only train on 2 GPUs.
 parser = argparse.ArgumentParser()
-parser.add_argument('--gpus', type=str, help='list of GPUs', default='-1')
 parser.add_argument('--exp_dir', default='exp/tmp',
                     help='Full path to save best validation model')
 
@@ -79,14 +77,12 @@ def main(conf):
                                        verbose=1)
 
     # Don't ask GPU if they are not available.
-    if not torch.cuda.is_available():
-        print('No available GPU were found, set gpus to None')
-        conf['main_args']['gpus'] = None
+    gpus = -1 if torch.cuda.is_available() else None
     trainer = pl.Trainer(max_nb_epochs=conf['training']['epochs'],
                          checkpoint_callback=checkpoint,
                          early_stop_callback=early_stopping,
                          default_save_path=exp_dir,
-                         gpus=conf['main_args']['gpus'],
+                         gpus=gpus,
                          distributed_backend='dp',
                          train_percent_check=1.0,  # Useful for fast experiment
                          gradient_clip_val=5.,)


### PR DESCRIPTION
They are not used because --id controls that in run.sh. 
There is no point to specify it twice.

Maybe the line just above the Trainer definition could be removed as well, I'll have to test it.