### PR TITLE
[egs] Fix wavfiles saving in eval.py for enh_single and enh_both task

### DIFF
--- a/egs/kinect-wsj/DeepClustering/eval.py
+++ b/egs/kinect-wsj/DeepClustering/eval.py
@@ -65,7 +65,7 @@ def main(conf):
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
         sources_np = sources.cpu().data.numpy()
-        est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
+        est_sources_np = reordered_sources.squeeze(0).cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'],
                                   metrics_list=compute_metrics)

--- a/egs/kinect-wsj/DeepClustering/eval.py
+++ b/egs/kinect-wsj/DeepClustering/eval.py
@@ -64,7 +64,7 @@ def main(conf):
         loss, reordered_sources = loss_func(est_sources, sources[None],
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
-        sources_np = sources.squeeze().cpu().data.numpy()
+        sources_np = sources.cpu().data.numpy()
         est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'],

--- a/egs/librimix/ConvTasNet/eval.py
+++ b/egs/librimix/ConvTasNet/eval.py
@@ -70,7 +70,7 @@ def main(conf):
                                             return_est=True)
         mix_np = mix.cpu().data.numpy()
         sources_np = sources.cpu().data.numpy()
-        est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
+        est_sources_np = reordered_sources.squeeze(0).cpu().data.numpy()
         # For each utterance, we get a dictionary with the mixture path,
         # the input and output metrics
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,

--- a/egs/librimix/ConvTasNet/eval.py
+++ b/egs/librimix/ConvTasNet/eval.py
@@ -69,7 +69,7 @@ def main(conf):
         loss, reordered_sources = loss_func(est_sources, sources[None],
                                             return_est=True)
         mix_np = mix.cpu().data.numpy()
-        sources_np = sources.squeeze().cpu().data.numpy()
+        sources_np = sources.cpu().data.numpy()
         est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
         # For each utterance, we get a dictionary with the mixture path,
         # the input and output metrics

--- a/egs/wham/ConvTasNet/eval.py
+++ b/egs/wham/ConvTasNet/eval.py
@@ -61,7 +61,7 @@ def main(conf):
         loss, reordered_sources = loss_func(est_sources, sources[None],
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
-        sources_np = sources.squeeze().cpu().data.numpy()
+        sources_np = sources.cpu().data.numpy()
         est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'])

--- a/egs/wham/ConvTasNet/eval.py
+++ b/egs/wham/ConvTasNet/eval.py
@@ -62,7 +62,7 @@ def main(conf):
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
         sources_np = sources.cpu().data.numpy()
-        est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
+        est_sources_np = reordered_sources.squeeze(0).cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'])
         utt_metrics['mix_path'] = test_set.mix[idx][0]

--- a/egs/wham/DPRNN/eval.py
+++ b/egs/wham/DPRNN/eval.py
@@ -61,7 +61,7 @@ def main(conf):
         loss, reordered_sources = loss_func(est_sources, sources[None],
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
-        sources_np = sources.squeeze().cpu().data.numpy()
+        sources_np = sources.cpu().data.numpy()
         est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'])

--- a/egs/wham/DPRNN/eval.py
+++ b/egs/wham/DPRNN/eval.py
@@ -62,7 +62,7 @@ def main(conf):
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
         sources_np = sources.cpu().data.numpy()
-        est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
+        est_sources_np = reordered_sources.squeeze(0).cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'])
         utt_metrics['mix_path'] = test_set.mix[idx][0]

--- a/egs/wham/DynamicMixing/eval.py
+++ b/egs/wham/DynamicMixing/eval.py
@@ -60,7 +60,7 @@ def main(conf):
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
         sources_np = sources.cpu().data.numpy()
-        est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
+        est_sources_np = reordered_sources.squeeze(0).cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'])
         utt_metrics['mix_path'] = test_set.mix[idx][0]

--- a/egs/wham/DynamicMixing/eval.py
+++ b/egs/wham/DynamicMixing/eval.py
@@ -59,7 +59,7 @@ def main(conf):
         loss, reordered_sources = loss_func(est_sources, sources[None],
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
-        sources_np = sources.squeeze().cpu().data.numpy()
+        sources_np = sources.cpu().data.numpy()
         est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'])

--- a/egs/wham/TwoStep/eval.py
+++ b/egs/wham/TwoStep/eval.py
@@ -63,7 +63,7 @@ def main(conf):
         loss, reordered_sources = loss_func(est_sources, sources[None],
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
-        sources_np = sources.squeeze().cpu().data.numpy()
+        sources_np = sources.cpu().data.numpy()
         est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'])

--- a/egs/wham/TwoStep/eval.py
+++ b/egs/wham/TwoStep/eval.py
@@ -64,7 +64,7 @@ def main(conf):
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
         sources_np = sources.cpu().data.numpy()
-        est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
+        est_sources_np = reordered_sources.squeeze(0).cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'])
         utt_metrics['mix_path'] = test_set.mix[idx][0]

--- a/egs/whamr/TasNet/eval.py
+++ b/egs/whamr/TasNet/eval.py
@@ -62,7 +62,7 @@ def main(conf):
         loss, reordered_sources = loss_func(est_sources, sources[None],
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
-        sources_np = sources.squeeze().cpu().data.numpy()
+        sources_np = sources.cpu().data.numpy()
         est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'])

--- a/egs/whamr/TasNet/eval.py
+++ b/egs/whamr/TasNet/eval.py
@@ -63,7 +63,7 @@ def main(conf):
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
         sources_np = sources.cpu().data.numpy()
-        est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
+        est_sources_np = reordered_sources.squeeze(0).cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'])
         utt_metrics['mix_path'] = test_set.mix[idx][0]

--- a/egs/wsj0-mix/DeepClustering/eval.py
+++ b/egs/wsj0-mix/DeepClustering/eval.py
@@ -61,7 +61,7 @@ def main(conf):
         loss, reordered_sources = loss_func(est_sources, sources[None],
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
-        sources_np = sources.squeeze().cpu().data.numpy()
+        sources_np = sources.cpu().data.numpy()
         est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'],

--- a/egs/wsj0-mix/DeepClustering/eval.py
+++ b/egs/wsj0-mix/DeepClustering/eval.py
@@ -62,7 +62,7 @@ def main(conf):
                                             return_est=True)
         mix_np = mix[None].cpu().data.numpy()
         sources_np = sources.cpu().data.numpy()
-        est_sources_np = reordered_sources.squeeze().cpu().data.numpy()
+        est_sources_np = reordered_sources.squeeze(0).cpu().data.numpy()
         utt_metrics = get_metrics(mix_np, sources_np, est_sources_np,
                                   sample_rate=conf['sample_rate'],
                                   metrics_list=compute_metrics)


### PR DESCRIPTION
Sources and estimates were completely squeezed before converting to numpy. 

In enhancement task, the sources have dimension (1, time) so that went to (time,) instead of staying (1, time)

Estimates have shape (batch, n_src, time), which is (1, 1, time) which should be squeeze to (1, time) instead of (time,) 

Closes #139 
