### PR TITLE
Fix librimix corrected

### DIFF
--- a/egs/librimix/ConvTasNet/eval.py
+++ b/egs/librimix/ConvTasNet/eval.py
@@ -5,6 +5,7 @@ import torch
 import yaml
 import json
 import argparse
+import numpy as np
 import pandas as pd
 from tqdm import tqdm
 from pprint import pprint
@@ -87,6 +88,7 @@ def main(conf):
                 sf.write(local_save_dir + "s{}.wav".format(src_idx), src,
                          conf['sample_rate'])
             for src_idx, est_src in enumerate(est_sources_np):
+                est_src *= np.max(np.abs(mix_np))/np.max(np.abs(est_src))
                 sf.write(local_save_dir + "s{}_estimate.wav".format(src_idx),
                          est_src, conf['sample_rate'])
             # Write local metrics to the example folder.

--- a/egs/librimix/ConvTasNet/local/prepare_data.sh
+++ b/egs/librimix/ConvTasNet/local/prepare_data.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 
 storage_dir=
-n_src=
 python_path=python
 
 . ./utils/parse_options.sh
 
-current_dir= pwd
+current_dir=$(pwd)
 # Clone LibriMix repo
 git clone https://github.com/JorisCos/LibriMix
 
 # Run generation script
 cd LibriMix
-. generate_librimix.sh $storage_dir $n_src
+. generate_librimix.sh $storage_dir
 
 cd $current_dir
-$python_path local/create_local_metadata.py --librimix_dir $storage_dir/Libri$n_src"Mix"
+$python_path local/create_local_metadata.py --librimix_dir $storage_dir/LibriMix
 

--- a/egs/librimix/ConvTasNet/local/prepare_data.sh
+++ b/egs/librimix/ConvTasNet/local/prepare_data.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 storage_dir=
+n_src=
 python_path=python
 
 . ./utils/parse_options.sh
@@ -14,5 +15,5 @@ cd LibriMix
 . generate_librimix.sh $storage_dir
 
 cd $current_dir
-$python_path local/create_local_metadata.py --librimix_dir $storage_dir/LibriMix
+$python_path local/create_local_metadata.py --librimix_dir $storage_dir/Libri$n_src"Mix"
 

--- a/egs/librimix/ConvTasNet/run.sh
+++ b/egs/librimix/ConvTasNet/run.sh
@@ -43,7 +43,7 @@ test_dir=data/wav8k/min/test
 sample_rate=8000
 n_src=2
 segment=3
-task=sep_clean
+task=sep_clean  # one of 'enh_single', 'enh_both', 'sep_clean', 'sep_noisy'
 
 . utils/parse_options.sh
 
@@ -83,6 +83,7 @@ if [[ $stage -le 1 ]]; then
 		--valid_dir $valid_dir \
 		--sample_rate $sample_rate \
 		--n_src $n_src \
+		--task $task \
 		--segment $segment | tee logs/train_${tag}.log
 	cp logs/train_${tag}.log $expdir/train.log
 

--- a/egs/librimix/ConvTasNet/run.sh
+++ b/egs/librimix/ConvTasNet/run.sh
@@ -50,7 +50,7 @@ task=sep_clean  # one of 'enh_single', 'enh_both', 'sep_clean', 'sep_noisy'
 
 if [[ $stage -le  0 ]]; then
 	echo "Stage 0: Generating Librimix dataset"
-  . local/prepare_data.sh --storage_dir $storage_dir
+  . local/prepare_data.sh --storage_dir $storage_dir --n_src $n_src
 fi
 
 # Generate a random ID for the run if no tag is specified

--- a/egs/librimix/ConvTasNet/run.sh
+++ b/egs/librimix/ConvTasNet/run.sh
@@ -50,7 +50,7 @@ task=sep_clean
 
 if [[ $stage -le  0 ]]; then
 	echo "Stage 0: Generating Librimix dataset"
-  . local/prepare_data.sh --storage_dir $storage_dir --n_src $n_src
+  . local/prepare_data.sh --storage_dir $storage_dir
 fi
 
 # Generate a random ID for the run if no tag is specified


### PR DESCRIPTION
Hello again,
This time with a cleaner commit history and your suggestions.

Regarding the normalization before writing to disk, anything that avoids significant amount of clipping is possible. Matching the peak value to that of the mixture as you suggested is one possibility, so is matching the energy of the target source but I am not sure if any of these really matters.

Cheers,
Mathieu