### PR TITLE
ignore exp dirs in recipe directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ venv.bak/
 /.idea/dictionaries/mparient.xml
 /.idea/inspectionProfiles/profiles_settings.xml
 /.idea/vcs.xml
+
+# Egs
+egs/**/exp

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Project specific
 uploader_info.yml
+egs/**/exp
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -114,6 +115,3 @@ venv.bak/
 /.idea/dictionaries/mparient.xml
 /.idea/inspectionProfiles/profiles_settings.xml
 /.idea/vcs.xml
-
-# Egs
-egs/**/exp


### PR DESCRIPTION
Fixes #149.

Wasn't really sure what was the best place in `.gitignore` for these lines