### PR TITLE
[src & tests] Support filenames at the input of `separate`

### DIFF
--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -18,7 +18,7 @@ def test_convtasnet_sep():
     out = nnet.separate(wav)
     assert isinstance(out, np.ndarray)
     # Test str input
-    sf.write('tmp.wav', wav, 8000)
+    sf.write('tmp.wav', wav[0], 8000)
     nnet.separate('tmp.wav')
 
 

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -2,6 +2,7 @@ import torch
 import pytest
 from torch.testing import assert_allclose
 import numpy as np
+import soundfile as sf
 from asteroid.models import ConvTasNet, DPRNNTasNet
 
 
@@ -16,6 +17,9 @@ def test_convtasnet_sep():
     wav = np.random.randn(1, 800).astype('float32')
     out = nnet.separate(wav)
     assert isinstance(out, np.ndarray)
+    # Test str input
+    sf.write('tmp.wav', wav, 8000)
+    nnet.separate('tmp.wav')
 
 
 @pytest.mark.parametrize('fb', ['free', 'stft', 'analytic_free', 'param_sinc'])


### PR DESCRIPTION
From now on, this will be possible: 

```python
from asteroid import DPRNNTasNet
model = DPRNNTasNet('mpariente/DPRNNTasNet_WHAM!_sepclean')
model.separate('path_to your_file.wav')
```
And the estimates will be saved in `path_to_file_est%i.wav`.