### PR TITLE
Slicer and an unslicer

### DIFF
--- a/asteroid/utils/torch_utils.py
+++ b/asteroid/utils/torch_utils.py
@@ -125,23 +125,23 @@ def are_models_equal(model1, model2):
     return True
 
 
-def slice(sources, w_size=16384, h_size=16384 // 2):
+def slice(sources, w_size=16384, stride=16384 // 2):
     """  Slice a signal in slices of size w_size
 
      Args:
          sources (torch.Tensor): sources of shape [nb_sources,channels,samples]
          w_size (int): size of the window
-         h_size (int): size of the stride
+         stride (int): size of the stride
      Returns:
          sliced signal (torch.Tensor): shape [nb_sources,nb_slices,channels,
                                               samples]
      """
     # stride must be shorter than window
-    if h_size < w_size / 2:
+    if stride < w_size / 2:
         raise ValueError(
             f"You can't have a stride smaller than half the window")
     # stride must be shorter than window
-    if h_size > w_size:
+    if stride > w_size:
         raise ValueError(
             f"You can't have a stride larger than the window")
     # Get source length
@@ -150,18 +150,18 @@ def slice(sources, w_size=16384, h_size=16384 // 2):
     if len_s > w_size:
         padding = 0
         # Automatic padding
-        if (len_s - w_size) % h_size != 0:
+        if (len_s - w_size) % stride != 0:
             padded = torch.zeros((sources.size(0), sources.size(1),
                                   sources.size(2) + w_size - (len_s - w_size) %
-                                  h_size))
+                                  stride))
             padded[:, :, :len_s] = sources
             sources = padded
             len_s = sources.size(-1)
-        nb_slices = int((len_s - w_size) // h_size) + 1
-        sliced = torch.zeros((sources.size(0),  nb_slices, sources.size(1),
+        nb_slices = int((len_s - w_size) // stride) + 1
+        sliced = torch.zeros((sources.size(0), nb_slices, sources.size(1),
                               w_size))
         for j in range(nb_slices):
-            sliced[:, j, :, :] = sources[:, :, j * h_size: j * h_size + w_size]
+            sliced[:, j, :, :] = sources[:, :, j * stride: j * stride + w_size]
         return sliced
     # If source is smaller then pad it to w_size
     if len_s < w_size:
@@ -173,7 +173,7 @@ def slice(sources, w_size=16384, h_size=16384 // 2):
     return sources.unsqueeze(1)
 
 
-def unslice(sources, original_shape, w_size=16384, h_size=16384 // 2):
+def unslice(sources, w_size=16384, stride=16384 // 2,original_shape=None):
     """  Reconstruct signal from sliced signal
 
      Args:
@@ -181,14 +181,14 @@ def unslice(sources, original_shape, w_size=16384, h_size=16384 // 2):
                                                    channels, samples]
          original_shape (torch.size): size of the original signal
          w_size (int): size of the window
-         h_size (int): size of the stride
+         stride (int): size of the stride
      Returns:
          reconstructed (torch.Tensor): reconstruced signal
           of shape [nb_sources,channels,samples]
      """
 
     # Define Hanning windows
-    w = torch.hann_window((w_size - h_size) * 2,dtype=sources.dtype)
+    w = torch.hann_window((w_size - stride) * 2, dtype=sources.dtype)
     # Ascending part
     w_up = w[:w.size(0) // 2]
     # Descending part
@@ -196,34 +196,30 @@ def unslice(sources, original_shape, w_size=16384, h_size=16384 // 2):
     # Number of slices
     n_slices = sources.size(1)
     # Create output
-    reconstructed = torch.zeros((sources.size(0),sources.size(2),
-                                 w_size + h_size * (n_slices - 1)))
+    reconstructed = torch.zeros((sources.size(0), sources.size(2),
+                                 w_size + stride * (n_slices - 1)))
     # Apply w_down to beginning of the first slice
-    reconstructed[:, :, : w_size - h_size] += sources[:, 0, :, :w_size - h_size] \
-                                           * w_down
+    reconstructed[:, :, : w_size - stride] += sources[:, 0, :,
+                                              :w_size - stride] \
+                                              * w_down
     # Reconstruct the signal from the slice
     for n_slice in range(n_slices):
-        start = n_slice * h_size
-        end = start + w_size - h_size
-        reconstructed[:, :, start:end] += sources[:,  n_slice, :,
-                                       :w_size - h_size] * w_up
-        start = end
-        end = start + w_size - 2 * (w_size - h_size)
+        start = n_slice * stride
+        end = start + w_size - stride
         reconstructed[:, :, start:end] += sources[:, n_slice, :,
-                                       w_size - h_size: h_size]
+                                          :w_size - stride] * w_up
         start = end
-        end = start + w_size - h_size
-        reconstructed[:, :, start:end] += sources[:, n_slice, :, h_size:] \
+        end = start + w_size - 2 * (w_size - stride)
+        reconstructed[:, :, start:end] += sources[:, n_slice, :,
+                                          w_size - stride: stride]
+        start = end
+        end = start + w_size - stride
+        reconstructed[:, :, start:end] += sources[:, n_slice, :, stride:] \
                                           * w_down
     # Correct the end of the signal with w_up
-    reconstructed[:, :, h_size * (n_slice + 1):] += sources[:, -1, :, h_size:] \
+    reconstructed[:, :, stride * (n_slice + 1):] += sources[:, -1, :, stride:] \
                                                     * w_up
     # Cut unwanted padding
-    reconstructed = reconstructed[:, :, :original_shape[-1]]
+    if original_shape is not None:
+        reconstructed = reconstructed[:, :, :original_shape[-1]]
     return reconstructed
-
-import torch
-x = torch.randn(10, 1, 16384)
-sliced = slice(x)
-unsliced = unslice(sliced, x.shape)
-assert torch.mean(x-unsliced) < 1E-6

--- a/tests/utils/torch_utils_test.py
+++ b/tests/utils/torch_utils_test.py
@@ -36,9 +36,11 @@ def test_loader_module():
 def test_loader_submodule():
     class SuperModule(nn.Module):
         """ nn.Module subclass that holds a model under self.whoever """
+
         def __init__(self, sub_model):
             super().__init__()
             self.whoever = sub_model
+
     model = SuperModule(nn.Sequential(nn.Linear(10, 10)))
     # Keys in state_dict will be whoever.0.weight, whoever.0.bias
     state_dict = model.state_dict()
@@ -53,3 +55,13 @@ def test_loader_submodule():
     # Apply our workaround torch_utils.load_state_dict_in and assert True.
     model_2 = torch_utils.load_state_dict_in(state_dict, model_2)
     assert torch_utils.are_models_equal(model, model_2)
+
+
+def test_slicer():
+    x = torch.randn(10, 2, 16384)
+    sliced = torch_utils.slice(x)
+    unsliced = torch_utils.unslice(sliced, x.shape)
+    result = False
+    if torch.mean(x - unsliced) < 1E-6:
+        result = True
+    assert result

--- a/tests/utils/torch_utils_test.py
+++ b/tests/utils/torch_utils_test.py
@@ -2,6 +2,7 @@ import torch
 import pytest
 from torch import nn
 from asteroid import torch_utils
+from torch.testing import assert_allclose
 
 
 def test_pad():
@@ -58,10 +59,7 @@ def test_loader_submodule():
 
 
 def test_slicer():
-    x = torch.randn(10, 2, 16384)
+    x = torch.randn(10, 2, 16384 + 200)
     sliced = torch_utils.slice(x)
     unsliced = torch_utils.unslice(sliced, x.shape)
-    result = False
-    if torch.mean(x - unsliced) < 1E-6:
-        result = True
-    assert result
+    assert_allclose(x, unsliced, rtol=0, atol=1E-6)


### PR DESCRIPTION
### About this PR
This PR introduce a slicer and an unslicer to slice signals, feed the sliced signals to a model and reconstruct the unsliced signal afterwards. This could be useful for very long signals that may cause code to break and also allows models (like SEGAN) that take a precise input length to handle longer signals.

### Proposed slicer
The proposed slicer uses hanning window and can handle overlap between 0 to 50 %. I did not find an elegant way to implement a slicer where more than two chunks are overlapping at the same time. Small numerical errors are introduced during the reconstruction phase they are around 1E-7.