### PR TITLE
Feat wise global layernorm

### DIFF
--- a/asteroid/masknn/norms.py
+++ b/asteroid/masknn/norms.py
@@ -78,6 +78,30 @@ class CumLN(_LayerNorm):
         return self.apply_gain_and_bias((x - cum_mean) / (cum_var + EPS).sqrt())
 
 
+class FeatsGlobLN(_LayerNorm):
+    """feature-wise global Layer Normalization (FeatsGlobLN).
+    Applies normalization over frames for each channel."""
+
+    def forward(self, x):
+        """ Applies forward pass.
+
+        Works for any input size > 2D.
+
+        Args:
+            x (:class:`torch.Tensor`): `[batch, chan, time]`
+
+        Returns:
+            :class:`torch.Tensor`: chanLN_x `[batch, chan, time]`
+        """
+
+        stop = len(x.size())
+        dims = list(range(1, stop))
+
+        mean = torch.mean(x, dim=dims, keepdim=True)
+        var = torch.var(x, dim=dims, keepdim=True, unbiased=False)
+        return self.apply_gain_and_bias((x - mean) / (var + EPS).sqrt())
+
+
 class BatchNorm(_BatchNorm):
     """Wrapper class for pytorch BatchNorm1D and BatchNorm2D"""
     def _check_input_dim(self, input):
@@ -87,6 +111,7 @@ class BatchNorm(_BatchNorm):
 
 # Aliases.
 gLN = GlobLN
+fgLN = FeatsGlobLN
 cLN = ChanLN
 cgLN = CumLN
 bN = BatchNorm

--- a/asteroid/masknn/norms.py
+++ b/asteroid/masknn/norms.py
@@ -95,7 +95,7 @@ class FeatsGlobLN(_LayerNorm):
         """
 
         stop = len(x.size())
-        dims = list(range(1, stop))
+        dims = list(range(2, stop))
 
         mean = torch.mean(x, dim=dims, keepdim=True)
         var = torch.var(x, dim=dims, keepdim=True, unbiased=False)

--- a/asteroid/masknn/norms.py
+++ b/asteroid/masknn/norms.py
@@ -109,6 +109,7 @@ class BatchNorm(_BatchNorm):
             raise ValueError('expected 4D or 3D input (got {}D input)'
                              .format(input.dim()))
 
+
 # Aliases.
 gLN = GlobLN
 fgLN = FeatsGlobLN

--- a/tests/masknn/norms_test.py
+++ b/tests/masknn/norms_test.py
@@ -4,7 +4,7 @@ import torch
 from asteroid.masknn import norms
 
 
-@pytest.mark.parametrize("norm_str", ["gLN", "cLN", "cgLN", "bN"])
+@pytest.mark.parametrize("norm_str", ["gLN", "cLN", "cgLN", "bN", "fgLN"])
 @pytest.mark.parametrize("channel_size", [8, 128, 4])
 def test_norms(norm_str, channel_size):
     norm_layer = norms.get(norm_str)


### PR DESCRIPTION
Feature-wise global layer normalization as it is used in TCN++ in FUSS and firstly proposed in Universal Sound Separation. 
Normalization is applied over all frames for each channel. 