### PR TITLE
[egs] EarlyStopping Patience to 30 instead of 10. 

### DIFF
--- a/egs/dns_challenge/baseline/train.py
+++ b/egs/dns_challenge/baseline/train.py
@@ -64,7 +64,7 @@ def main(conf):
                                  mode='min', save_top_k=5, verbose=1)
     early_stopping = False
     if conf['training']['early_stop']:
-        early_stopping = EarlyStopping(monitor='val_loss', patience=10,
+        early_stopping = EarlyStopping(monitor='val_loss', patience=30,
                                        verbose=1)
 
     # Don't ask GPU if they are not available.

--- a/egs/kinect-wsj/DeepClustering/train.py
+++ b/egs/kinect-wsj/DeepClustering/train.py
@@ -55,7 +55,7 @@ def main(conf):
                                  mode='min', save_top_k=5, verbose=1)
     early_stopping = False
     if conf['training']['early_stop']:
-        early_stopping = EarlyStopping(monitor='val_loss', patience=10,
+        early_stopping = EarlyStopping(monitor='val_loss', patience=30,
                                        verbose=1)
     gpus=-1
     # Don't ask GPU if they are not available.

--- a/egs/librimix/ConvTasNet/train.py
+++ b/egs/librimix/ConvTasNet/train.py
@@ -75,7 +75,7 @@ def main(conf):
                                  mode='min', save_top_k=5, verbose=1)
     early_stopping = False
     if conf['training']['early_stop']:
-        early_stopping = EarlyStopping(monitor='val_loss', patience=10,
+        early_stopping = EarlyStopping(monitor='val_loss', patience=30,
                                        verbose=1)
 
     # Don't ask GPU if they are not available.

--- a/egs/wham/ConvTasNet/train.py
+++ b/egs/wham/ConvTasNet/train.py
@@ -72,7 +72,7 @@ def main(conf):
                                  mode='min', save_top_k=5, verbose=1)
     early_stopping = False
     if conf['training']['early_stop']:
-        early_stopping = EarlyStopping(monitor='val_loss', patience=10,
+        early_stopping = EarlyStopping(monitor='val_loss', patience=30,
                                        verbose=1)
 
     # Don't ask GPU if they are not available.

--- a/egs/wham/DPRNN/train.py
+++ b/egs/wham/DPRNN/train.py
@@ -70,7 +70,7 @@ def main(conf):
                                  mode='min', save_top_k=5, verbose=1)
     early_stopping = False
     if conf['training']['early_stop']:
-        early_stopping = EarlyStopping(monitor='val_loss', patience=10,
+        early_stopping = EarlyStopping(monitor='val_loss', patience=30,
                                        verbose=1)
 
     # Don't ask GPU if they are not available.

--- a/egs/wham/DynamicMixing/train.py
+++ b/egs/wham/DynamicMixing/train.py
@@ -82,7 +82,7 @@ def main(conf):
                                  mode='min', save_top_k=5, verbose=1)
     early_stopping = False
     if conf['training']['early_stop']:
-        early_stopping = EarlyStopping(monitor='val_loss', patience=10,
+        early_stopping = EarlyStopping(monitor='val_loss', patience=30,
                                        verbose=1)
 
     # Don't ask GPU if they are not available.

--- a/egs/wham/TwoStep/train.py
+++ b/egs/wham/TwoStep/train.py
@@ -91,7 +91,7 @@ def train_model_part(conf, train_part='filterbank', pretrained_filterbank=None):
                                  mode='min', save_top_k=1, verbose=1)
     early_stopping = False
     if conf[train_part + '_training'][train_part[0] + '_early_stop']:
-        early_stopping = EarlyStopping(monitor='val_loss', patience=10,
+        early_stopping = EarlyStopping(monitor='val_loss', patience=30,
                                        verbose=1)
     # Don't ask GPU if they are not available.
     gpus = -1 if torch.cuda.is_available() else None

--- a/egs/whamr/TasNet/train.py
+++ b/egs/whamr/TasNet/train.py
@@ -73,7 +73,7 @@ def main(conf):
                                  mode='min', save_top_k=5, verbose=1)
     early_stopping = False
     if conf['training']['early_stop']:
-        early_stopping = EarlyStopping(monitor='val_loss', patience=10,
+        early_stopping = EarlyStopping(monitor='val_loss', patience=30,
                                        verbose=1)
 
     # Don't ask GPU if they are not available.

--- a/egs/wsj0-mix/DeepClustering/train.py
+++ b/egs/wsj0-mix/DeepClustering/train.py
@@ -55,7 +55,7 @@ def main(conf):
                                  mode='min', save_top_k=5, verbose=1)
     early_stopping = False
     if conf['training']['early_stop']:
-        early_stopping = EarlyStopping(monitor='val_loss', patience=10,
+        early_stopping = EarlyStopping(monitor='val_loss', patience=30,
                                        verbose=1)
     gpus=-1
     # Don't ask GPU if they are not available.


### PR DESCRIPTION
EarlyStopping was broken in pl 0.6.0 and now that it works, we are stopping too early.
I saw this behavior for DPRNN several times etc.. 
Related issue: #177 