### PR TITLE
STOI loss example: Add sample rate

### DIFF
--- a/asteroid/losses/stoi.py
+++ b/asteroid/losses/stoi.py
@@ -6,7 +6,7 @@ Examples:
     >>> from asteroid.losses import PITLossWrapper
     >>> targets = torch.randn(10, 2, 32000)
     >>> est_targets = torch.randn(10, 2, 32000)
-    >>> loss_func = PITLossWrapper(NegSTOILoss(), pit_from='pw_pt')
+    >>> loss_func = PITLossWrapper(NegSTOILoss(sample_rate=8000), pit_from='pw_pt')
     >>> loss = loss_func(est_targets, targets)
 """
 


### PR DESCRIPTION
I was trying STOI loss and realised after listening to some early examples that something is wrong with high frequencies.  Realised that I forgot to set the sample rate param for STOI loss.

This PR adds it to the docstring example.

I'd go as far and advocate for making `sample_rate` and *required* parameter that does not have a default – I would expect that almost everyone has to use resampling anyways because they're training in some other sample rate than 10kHz.