### PR TITLE
[tests] Add precommit hook with black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+default_language_version:
+  python: python3.6
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+
+  - repo: local
+    hooks:
+      - id: black
+        name: black
+        entry: python -m black
+        args: [--skip-string-normalization, --config, ./pyproject.toml]
+        language: system
+        types: [python]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,49 +1,71 @@
 ## How to contribute
 
-The general way to contribute to Asteroid is to fork the main 
+The general way to contribute to Asteroid is to fork the main
 repository on GitHub:
 1. Fork the [main repo][asteroid] and `git clone` it.
-2. Make your changes, test them, commit them and push them to your fork. 
+2. Make your changes, test them, commit them and push them to your fork.
 3. You can open a pull request on GitHub when you're satisfied.
 
-If you made changes to the source code, you'll want to try them out without 
+If you made changes to the source code, you'll want to try them out without
 installing asteroid everytime you change something.
-To do that, install asteroid in develop mode either with pip 
-```pip install -e .[tests]``` or with python ```python setup.py develop```. 
+To do that, install asteroid in develop mode either with pip
+```pip install -e .[tests]``` or with python ```python setup.py develop```.
+
+To avoid formatting roundtrips in PRs, Asteroid relies on [`black`](https://github.com/psf/black)
+and [`pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks) to handle formatting
+for us. You'll need to install `requirements.txt` and install git hooks with
+`pre-commit install`.
+
+Here is a summary:
+
+```bash
+### Install
+git clone your_fork_url
+cd asteroid
+pip install -r requirements.txt
+pip install -e .
+pre-commit install  # To run black before commit
+
+# Make your changes
+# Test them locally
+# Commit your changes
+# Push your changes
+# Open a PR !
+```
 
 ### Source code contributions
-__All contributions to the source code of asteroid should be documented 
-and unit-tested__.   
-See [here](./tests) to run the tests with coverage reports.  
-Docstrings follow the [Google format][docstrings], have a look at other 
+__All contributions to the source code of asteroid should be documented
+and unit-tested__.
+See [here](./tests) to run the tests with coverage reports.
+Docstrings follow the [Google format][docstrings], have a look at other
 docstrings in the codebase for examples. Examples in docstrings can
 be bery useful, don't hesitate to add some!
 
 
 ### Writing new recipes.
-Most new recipes should follow the standard format that is described 
+Most new recipes should follow the standard format that is described
 [here](./egs). We are not dogmatic about it, but another organization should
-be explained and motivated.  
+be explained and motivated.
 We welcome any recipe on standard or new datasets, with standard or new
-architectures. You can even link a paper submission with a PR number 
-if you'd like!  
+architectures. You can even link a paper submission with a PR number
+if you'd like!
 
 ### Improving the docs.
-If you found a typo, think something could be more explicit etc... 
+If you found a typo, think something could be more explicit etc...
 Improving the documentation is always welcome. The instructions to install
-dependencies and build the docs can be found [here](./docs).  
-Docstrings follow the [Google format][docstrings], have a look at other 
+dependencies and build the docs can be found [here](./docs).
+Docstrings follow the [Google format][docstrings], have a look at other
 docstrings in the codebase for examples.
 
 ### Coding style
-We use [PEP8 syntax conventions][pep8]. 
+We use [PEP8 syntax conventions][pep8].
 To make your life easier, we recommend running a PEP8 linter:
 
-- Install PEP8 packages: `pip install pep8 pytest-pep8 autopep8`  
+- Install PEP8 packages: `pip install pep8 pytest-pep8 autopep8`
 - Run a standalone PEP8 check: `py.test --pep8 -m pep8`
 
 
-If you have any question, [open an issue][issue] or [join the slack][slack], 
+If you have any question, [open an issue][issue] or [join the slack][slack],
 we'll be happy to help you.
 
 [asteroid]: https://github.com/mpariente/asteroid

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pb_bss_eval>=0.0.2
 torch_stoi>=0.0.1
 torch_optimizer>=0.0.1a12
 pre-commit
+black==19.10b0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytorch-lightning>=0.7.5,<0.8
 pb_bss_eval>=0.0.2
 torch_stoi>=0.0.1
 torch_optimizer>=0.0.1a12
+pre-commit


### PR DESCRIPTION
First steps towards adopting [`black`](https://github.com/psf/black) !

The idea is to gain time and energy :
- No need to think about code style when writing
- No need to worry about code style when reviewing (huge loss of time)
- Easier for new comers to open their PRs 

For now, we'll stick with 120 line length, but we'll probably move to 100 afterwards. 
Also need to add `flake8` but I don't know it much yet.

**Resources**
- [Django adopting black](https://github.com/django/deps/blob/master/accepted/0008-black.rst): see the end for the procedure we'll follow
- [Why prettier in JS](https://prettier.io/docs/en/why-prettier.html): good read.
- [Linus about line length](https://lkml.org/lkml/2020/5/29/1038).
