### PR TITLE
[src & tests] Fix serialization issues introduced in previous PR

### DIFF
--- a/asteroid/masknn/attention.py
+++ b/asteroid/masknn/attention.py
@@ -198,7 +198,7 @@ class DPTransformer(nn.Module):
     def get_config(self):
         config = {
             "in_chan": self.in_chan,
-            "ff_hid": self.hid_size,
+            "ff_hid": self.ff_hid,
             "n_heads": self.n_heads,
             "chunk_size": self.chunk_size,
             "hop_size": self.hop_size,

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -22,6 +22,7 @@ class BaseTasNet(nn.Module):
         self.masker = masker
         self.decoder = decoder
 
+        self.encoder_activation = encoder_activation
         if encoder_activation:
             self.enc_activation = activations.get(encoder_activation)()
         else:
@@ -166,7 +167,11 @@ class BaseTasNet(nn.Module):
             )
         # Merge all args under model_args.
         model_conf["model_name"] = self.__class__.__name__
-        model_conf["model_args"] = {**fb_config, **masknet_config}
+        model_conf["model_args"] = {
+            **fb_config,
+            **masknet_config,
+            "encoder_activation": self.encoder_activation,
+        }
         model_conf["state_dict"] = self.state_dict()
         # Additional infos
         infos = dict()

--- a/asteroid/models/conv_tasnet.py
+++ b/asteroid/models/conv_tasnet.py
@@ -59,6 +59,7 @@ class ConvTasNet(BaseTasNet):
         kernel_size=16,
         n_filters=512,
         stride=8,
+        encoder_activation="relu",
         **fb_kwargs,
     ):
         encoder, decoder = make_enc_dec(
@@ -86,4 +87,4 @@ class ConvTasNet(BaseTasNet):
             norm_type=norm_type,
             mask_act=mask_act,
         )
-        super().__init__(encoder, masker, decoder)
+        super().__init__(encoder, masker, decoder, encoder_activation=encoder_activation)

--- a/asteroid/models/dprnn_tasnet.py
+++ b/asteroid/models/dprnn_tasnet.py
@@ -68,6 +68,7 @@ class DPRNNTasNet(BaseTasNet):
         kernel_size=16,
         n_filters=64,
         stride=8,
+        encoder_activation="relu",
         **fb_kwargs,
     ):
         encoder, decoder = make_enc_dec(
@@ -98,4 +99,4 @@ class DPRNNTasNet(BaseTasNet):
             num_layers=num_layers,
             dropout=dropout,
         )
-        super().__init__(encoder, masker, decoder)
+        super().__init__(encoder, masker, decoder, encoder_activation=encoder_activation)

--- a/asteroid/models/dptnet.py
+++ b/asteroid/models/dptnet.py
@@ -43,7 +43,9 @@ class DPTNet(BaseTasNet):
             creation.
 
     References:
-        [1]
+        [1]: Jingjing Chen et al. "Dual-Path Transformer Network: Direct
+            Context-Aware Modeling for End-to-End Monaural Speech Separation"
+            Interspeech 2020.
     """
 
     def __init__(

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,11 @@
 comment: false
 coverage:
   status:
-    patch: false
-#      default:
-#        target: 60%
+    patch:
+      default:
+        target: 60%
     project:
       default:
-        target: auto # target is the base commit coverage
-        threshold: 10% # allow this little decrease on project
+        target: auto  # target is the base commit coverage
+        threshold: 10%  # allow this little decrease on project
         base: auto

--- a/tests/losses/loss_functions_test.py
+++ b/tests/losses/loss_functions_test.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from torch.testing import assert_allclose
+import warnings
 
 from asteroid.filterbanks import STFTFB, Encoder, transforms
 from asteroid.losses import PITLossWrapper
@@ -136,4 +137,6 @@ def test_negstoi_pit(n_src, sample_rate, use_vad, extended):
     )
     loss_func = PITLossWrapper(singlesrc_negstoi, pit_from="pw_pt")
     # Assert forward ok.
-    loss_func(est, ref)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        loss_func(est, ref)

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -3,8 +3,8 @@ import pytest
 from torch.testing import assert_allclose
 import numpy as np
 import soundfile as sf
-from asteroid.models import ConvTasNet, DPRNNTasNet
-from asteroid.models.sudormrf import SuDORMRF, SuDORMRFImproved
+from asteroid.models import ConvTasNet, DPRNNTasNet, DPTNet
+from asteroid.models import SuDORMRF, SuDORMRFImproved
 
 
 def test_convtasnet_sep():
@@ -81,3 +81,12 @@ def test_sudormrf_imp():
     )
     test_input = torch.randn(1, 801)
     model(test_input)
+
+
+def test_dptnet():
+    model = DPTNet(2, ff_hid=10, chunk_size=4, n_repeats=2)
+    test_input = torch.randn(1, 801)
+
+    model_conf = model.serialize()
+    reconstructed_model = DPTNet.from_pretrained(model_conf)
+    assert_allclose(model.separate(test_input), reconstructed_model(test_input))


### PR DESCRIPTION
### What this does.

- Add tests on attention module 
- #200 introduced the `encoder_activation` argument to `BaseTasNet` which was not serialized, this PR fixes that. 
- filter warning in loss tests for readable outputs 