### PR TITLE
[src & tests] Split SuDORMRF architectures in encoder/masker/decoder

### DIFF
--- a/asteroid/masknn/__init__.py
+++ b/asteroid/masknn/__init__.py
@@ -1,4 +1,4 @@
-from .convolutional import TDConvNet
+from .convolutional import TDConvNet, SuDORMRF, SuDORMRFImproved
 from .recurrent import DPRNN
 from .attention import DPTransformer
 
@@ -6,4 +6,6 @@ __all__ = [
     "TDConvNet",
     "DPRNN",
     "DPTransformer",
+    "SuDORMRF",
+    "SuDORMRFImproved",
 ]

--- a/asteroid/masknn/_local.py
+++ b/asteroid/masknn/_local.py
@@ -1,0 +1,125 @@
+from torch import nn
+from .norms import GlobLN
+
+
+class _ConvNormAct(nn.Module):
+    """ Convolution layer with normalization and a PReLU activation.
+
+    See license and copyright notices here
+        https://github.com/etzinis/sudo_rm_rf#copyright-and-license
+        https://github.com/etzinis/sudo_rm_rf/blob/master/LICENSE
+
+    Args
+        nIn: number of input channels
+        nOut: number of output channels
+        kSize: kernel size
+        stride: stride rate for down-sampling. Default is 1
+    """
+
+    def __init__(self, nIn, nOut, kSize, stride=1, groups=1, use_globln=False):
+
+        super().__init__()
+        padding = int((kSize - 1) / 2)
+        self.conv = nn.Conv1d(
+            nIn, nOut, kSize, stride=stride, padding=padding, bias=True, groups=groups
+        )
+        if use_globln:
+            self.norm = GlobLN(nOut)
+            self.act = nn.PReLU()
+        else:
+            self.norm = nn.GroupNorm(1, nOut, eps=1e-08)
+            self.act = nn.PReLU(nOut)
+
+    def forward(self, inp):
+        output = self.conv(inp)
+        output = self.norm(output)
+        return self.act(output)
+
+
+class _ConvNorm(nn.Module):
+    """ Convolution layer with normalization without activation.
+
+    See license and copyright notices here
+        https://github.com/etzinis/sudo_rm_rf#copyright-and-license
+        https://github.com/etzinis/sudo_rm_rf/blob/master/LICENSE
+
+
+    Args:
+        nIn: number of input channels
+        nOut: number of output channels
+        kSize: kernel size
+        stride: stride rate for down-sampling. Default is 1
+    """
+
+    def __init__(self, nIn, nOut, kSize, stride=1, groups=1):
+
+        super().__init__()
+        padding = int((kSize - 1) / 2)
+        self.conv = nn.Conv1d(
+            nIn, nOut, kSize, stride=stride, padding=padding, bias=True, groups=groups
+        )
+        self.norm = nn.GroupNorm(1, nOut, eps=1e-08)
+
+    def forward(self, inp):
+        output = self.conv(inp)
+        return self.norm(output)
+
+
+class _NormAct(nn.Module):
+    """ Normalization and PReLU activation.
+
+    See license and copyright notices here
+        https://github.com/etzinis/sudo_rm_rf#copyright-and-license
+        https://github.com/etzinis/sudo_rm_rf/blob/master/LICENSE
+
+    Args:
+         nOut: number of output channels
+    """
+
+    def __init__(self, nOut, use_globln=False):
+        super().__init__()
+        if use_globln:
+            self.norm = GlobLN(nOut)
+        else:
+            self.norm = nn.GroupNorm(1, nOut, eps=1e-08)
+        self.act = nn.PReLU(nOut)
+
+    def forward(self, inp):
+        output = self.norm(inp)
+        return self.act(output)
+
+
+class _DilatedConvNorm(nn.Module):
+    """ Dilated convolution with normalized output.
+
+    See license and copyright notices here
+        https://github.com/etzinis/sudo_rm_rf#copyright-and-license
+        https://github.com/etzinis/sudo_rm_rf/blob/master/LICENSE
+
+    Args:
+        nIn: number of input channels
+        nOut: number of output channels
+        kSize: kernel size
+        stride: optional stride rate for down-sampling
+        d: optional dilation rate
+    """
+
+    def __init__(self, nIn, nOut, kSize, stride=1, d=1, groups=1, use_globln=False):
+        super().__init__()
+        self.conv = nn.Conv1d(
+            nIn,
+            nOut,
+            kSize,
+            stride=stride,
+            dilation=d,
+            padding=((kSize - 1) // 2) * d,
+            groups=groups,
+        )
+        if use_globln:
+            self.norm = GlobLN(nOut)
+        else:
+            self.norm = nn.GroupNorm(1, nOut, eps=1e-08)
+
+    def forward(self, inp):
+        output = self.conv(inp)
+        return self.norm(output)

--- a/asteroid/masknn/convolutional.py
+++ b/asteroid/masknn/convolutional.py
@@ -212,13 +212,12 @@ class TDConvNet(nn.Module):
 
 
 class SuDORMRF(nn.Module):
-    """ SuDORMRF separation model, as described in [1].
+    """ SuDORMRF mask network, as described in [1].
 
     Args:
         in_chan (int): Number of input channels. Also number of output channels.
         n_src (int): Number of sources in the input mixtures.
-        bn_chan (int, optional): Number of bins in the bottleneck layer and the
-            UNet blocks.
+        bn_chan (int, optional): Number of bins in the bottleneck layer and the UNet blocks.
         num_blocks (int): Number of of UBlocks.
         upsampling_depth (int): Depth of upsampling.
         mask_act (str): Name of output activation.
@@ -293,13 +292,12 @@ class SuDORMRF(nn.Module):
 
 
 class SuDORMRFImproved(nn.Module):
-    """ Improved SuDORMRF separation model, as described in [1].
+    """ Improved SuDORMRF mask network, as described in [1].
 
     Args:
         in_chan (int): Number of input channels. Also number of output channels.
         n_src (int): Number of sources in the input mixtures.
-        bn_chan (int, optional): Number of bins in the bottleneck layer and the
-            UNet blocks.
+        bn_chan (int, optional): Number of bins in the bottleneck layer and the UNet blocks.
         num_blocks (int): Number of of UBlocks
         upsampling_depth (int): Depth of upsampling
         mask_act (str): Name of output activation.

--- a/asteroid/masknn/convolutional.py
+++ b/asteroid/masknn/convolutional.py
@@ -1,10 +1,12 @@
+import torch
 from torch import nn
 import warnings
-from ..utils.deprecation_utils import VisibleDeprecationWarning
-
 
 from . import norms, activations
+from .norms import GlobLN
 from ..utils import has_arg
+from ..utils.deprecation_utils import VisibleDeprecationWarning
+from ._local import _DilatedConvNorm, _NormAct, _ConvNormAct, _ConvNorm
 
 
 class Conv1DBlock(nn.Module):
@@ -207,3 +209,275 @@ class TDConvNet(nn.Module):
             "mask_act": self.mask_act,
         }
         return config
+
+
+class SuDORMRF(nn.Module):
+    """ SuDORMRF separation model, as described in [1].
+
+    Args:
+        in_chan (int): Number of input channels. Also number of output channels.
+        n_src (int): Number of sources in the input mixtures.
+        bn_chan (int, optional): Number of bins in the bottleneck layer and the
+            UNet blocks.
+        num_blocks (int): Number of of UBlocks.
+        upsampling_depth (int): Depth of upsampling.
+        mask_act (str): Name of output activation.
+
+    References:
+        [1] : "Sudo rm -rf: Efficient Networks for Universal Audio Source Separation",
+            Tzinis et al. MLSP 2020.
+    """
+
+    def __init__(
+        self, in_chan, n_src, bn_chan=128, num_blocks=16, upsampling_depth=4, mask_act="softmax",
+    ):
+        super().__init__()
+        self.in_chan = in_chan
+        self.n_src = n_src
+        self.bn_chan = bn_chan
+        self.num_blocks = num_blocks
+        self.upsampling_depth = upsampling_depth
+        self.mask_act = mask_act
+
+        # Norm before the rest, and apply one more dense layer
+        self.ln = nn.GroupNorm(1, in_chan, eps=1e-08)
+        self.l1 = nn.Conv1d(in_chan, bn_chan, kernel_size=1)
+
+        # Separation module
+        self.sm = nn.Sequential(
+            *[
+                UBlock(out_chan=bn_chan, in_chan=in_chan, upsampling_depth=upsampling_depth,)
+                for _ in range(num_blocks)
+            ]
+        )
+
+        if bn_chan != in_chan:
+            self.reshape_before_masks = nn.Conv1d(bn_chan, in_chan, kernel_size=1)
+
+        # Masks layer
+        self.m = nn.Conv2d(
+            1, n_src, kernel_size=(in_chan + 1, 1), padding=(in_chan - in_chan // 2, 0),
+        )
+
+        # Get activation function.
+        mask_nl_class = activations.get(mask_act)
+        # For softmax, feed the source dimension.
+        if has_arg(mask_nl_class, "dim"):
+            self.output_act = mask_nl_class(dim=1)
+        else:
+            self.output_act = mask_nl_class()
+
+    def forward(self, x):
+        x = self.ln(x)
+        x = self.l1(x)
+        x = self.sm(x)
+
+        if self.out_chan != self.in_chan:
+            x = self.reshape_before_masks(x)
+
+        # Get output + activation
+        x = self.m(x.unsqueeze(1))
+        x = self.output_act(x)
+        return x
+
+    def get_config(self):
+        config = {
+            "in_chan": self.in_chan,
+            "n_src": self.n_src,
+            "bn_chan": self.bn_chan,
+            "num_blocks": self.num_blocks,
+            "upsampling_depth": self.upsampling_depth,
+            "mask_act": self.mask_act,
+        }
+        return config
+
+
+class SuDORMRFImproved(nn.Module):
+    """ Improved SuDORMRF separation model, as described in [1].
+
+    Args:
+        in_chan (int): Number of input channels. Also number of output channels.
+        n_src (int): Number of sources in the input mixtures.
+        bn_chan (int, optional): Number of bins in the bottleneck layer and the
+            UNet blocks.
+        num_blocks (int): Number of of UBlocks
+        upsampling_depth (int): Depth of upsampling
+        mask_act (str): Name of output activation.
+
+
+    References:
+        [1] : "Sudo rm -rf: Efficient Networks for Universal Audio Source Separation",
+            Tzinis et al. MLSP 2020.
+    """
+
+    def __init__(
+        self, in_chan, n_src, bn_chan=128, num_blocks=16, upsampling_depth=4, mask_act="relu",
+    ):
+        super().__init__()
+        self.in_chan = in_chan
+        self.n_src = n_src
+        self.bn_chan = bn_chan
+        self.num_blocks = num_blocks
+        self.upsampling_depth = upsampling_depth
+        self.mask_act = mask_act
+
+        # Norm before the rest, and apply one more dense layer
+        self.ln = GlobLN(in_chan)
+        self.bottleneck = nn.Conv1d(in_chan, bn_chan, kernel_size=1)
+
+        # Separation module
+        self.sm = nn.Sequential(
+            *[
+                UConvBlock(out_chan=bn_chan, in_chan=in_chan, upsampling_depth=upsampling_depth,)
+                for _ in range(num_blocks)
+            ]
+        )
+
+        mask_conv = nn.Conv1d(bn_chan, n_src * in_chan, 1)
+        self.mask_net = nn.Sequential(nn.PReLU(), mask_conv)
+
+        # Get activation function.
+        mask_nl_class = activations.get(mask_act)
+        # For softmax, feed the source dimension.
+        if has_arg(mask_nl_class, "dim"):
+            self.output_act = mask_nl_class(dim=1)
+        else:
+            self.output_act = mask_nl_class()
+
+    def forward(self, x):
+        x = self.ln(x)
+        x = self.bottleneck(x)
+        x = self.sm(x)
+
+        x = self.mask_net(x)
+        x = x.view(x.shape[0], self.n_src, self.in_chan, -1)
+        x = self.output_act(x)
+        return x
+
+    def get_config(self):
+        config = {
+            "in_chan": self.in_chan,
+            "n_src": self.n_src,
+            "bn_chan": self.bn_chan,
+            "num_blocks": self.num_blocks,
+            "upsampling_depth": self.upsampling_depth,
+            "mask_act": self.mask_act,
+        }
+        return config
+
+
+class _BaseUBlock(nn.Module):
+    def __init__(self, out_chan=128, in_chan=512, upsampling_depth=4, use_globln=False):
+        super().__init__()
+        self.proj_1x1 = _ConvNormAct(
+            out_chan, in_chan, 1, stride=1, groups=1, use_globln=use_globln
+        )
+        self.depth = upsampling_depth
+        self.spp_dw = nn.ModuleList()
+        self.spp_dw.append(
+            _DilatedConvNorm(
+                in_chan, in_chan, kSize=5, stride=1, groups=in_chan, d=1, use_globln=use_globln,
+            )
+        )
+
+        for i in range(1, upsampling_depth):
+            if i == 0:
+                stride = 1
+            else:
+                stride = 2
+            self.spp_dw.append(
+                _DilatedConvNorm(
+                    in_chan,
+                    in_chan,
+                    kSize=2 * stride + 1,
+                    stride=stride,
+                    groups=in_chan,
+                    d=1,
+                    use_globln=use_globln,
+                )
+            )
+        if upsampling_depth > 1:
+            self.upsampler = torch.nn.Upsample(
+                scale_factor=2,
+                # align_corners=True,
+                # mode='bicubic'
+            )
+
+
+class UBlock(_BaseUBlock):
+    """ Upsampling block.
+
+    Based on the following principle:
+        ``REDUCE ---> SPLIT ---> TRANSFORM --> MERGE``
+    """
+
+    def __init__(self, out_chan=128, in_chan=512, upsampling_depth=4):
+        super().__init__(out_chan, in_chan, upsampling_depth, use_globln=False)
+        self.conv_1x1_exp = _ConvNorm(in_chan, out_chan, 1, 1, groups=1)
+        self.final_norm = _NormAct(in_chan)
+        self.module_act = _NormAct(out_chan)
+
+    def forward(self, x):
+        """
+        Args:
+            x: input feature map
+
+        Returns:
+            transformed feature map
+        """
+
+        # Reduce --> project high-dimensional feature maps to low-dimensional space
+        output1 = self.proj_1x1(x)
+        output = [self.spp_dw[0](output1)]
+
+        # Do the downsampling process from the previous level
+        for k in range(1, self.depth):
+            out_k = self.spp_dw[k](output[-1])
+            output.append(out_k)
+
+        # Gather them now in reverse order
+        for _ in range(self.depth - 1):
+            resampled_out_k = self.upsampler(output.pop(-1))
+            output[-1] = output[-1] + resampled_out_k
+
+        expanded = self.conv_1x1_exp(self.final_norm(output[-1]))
+
+        return self.module_act(expanded + x)
+
+
+class UConvBlock(_BaseUBlock):
+    """ Block which performs successive downsampling and upsampling
+    in order to be able to analyze the input features in multiple resolutions.
+    """
+
+    def __init__(self, out_chan=128, in_chan=512, upsampling_depth=4):
+        super().__init__(out_chan, in_chan, upsampling_depth, use_globln=True)
+        self.final_norm = _NormAct(in_chan, use_globln=True)
+        self.res_conv = nn.Conv1d(in_chan, out_chan, 1)
+
+    def forward(self, x):
+        """
+        Args
+            x: input feature map
+
+        Returns:
+            transformed feature map
+        """
+        residual = x.clone()
+        # Reduce --> project high-dimensional feature maps to low-dimensional space
+        output1 = self.proj_1x1(x)
+        output = [self.spp_dw[0](output1)]
+
+        # Do the downsampling process from the previous level
+        for k in range(1, self.depth):
+            out_k = self.spp_dw[k](output[-1])
+            output.append(out_k)
+
+        # Gather them now in reverse order
+        for _ in range(self.depth - 1):
+            resampled_out_k = self.upsampler(output.pop(-1))
+            output[-1] = output[-1] + resampled_out_k
+
+        expanded = self.final_norm(output[-1])
+
+        return self.res_conv(expanded) + residual

--- a/asteroid/masknn/convolutional.py
+++ b/asteroid/masknn/convolutional.py
@@ -271,7 +271,7 @@ class SuDORMRF(nn.Module):
         x = self.l1(x)
         x = self.sm(x)
 
-        if self.out_chan != self.in_chan:
+        if self.bn_chan != self.in_chan:
             x = self.reshape_before_masks(x)
 
         # Get output + activation

--- a/asteroid/models/__init__.py
+++ b/asteroid/models/__init__.py
@@ -1,7 +1,7 @@
 # Models
 from .conv_tasnet import ConvTasNet
 from .dprnn_tasnet import DPRNNTasNet
-from .sudormrf import SuDORMRFImproved, SuDORMRF
+from .sudormrf import SuDORMRFImprovedNet, SuDORMRFNet
 from .dptnet import DPTNet
 
 # Sharing-related
@@ -10,8 +10,8 @@ from .publisher import save_publishable, upload_publishable
 __all__ = [
     "ConvTasNet",
     "DPRNNTasNet",
-    "SuDORMRFImproved",
-    "SuDORMRF",
+    "SuDORMRFImprovedNet",
+    "SuDORMRFNet",
     "DPTNet",
     "save_publishable",
     "upload_publishable",

--- a/asteroid/models/sudormrf.py
+++ b/asteroid/models/sudormrf.py
@@ -1,244 +1,19 @@
-"""Copied and adapted from: https://github.com/etzinis/sudo_rm_rf
-
-University of Illinois Open Source License
-
-Copyright © 2020, University of Illinois at Urbana Champaign. All rights reserved.
-
-Developed by: Efthymios Tzinis 1, Zhepei Wang 1 and Paris Smaragdis 1,2
-
-1: University of Illinois at Urbana-Champaign
-
-2: Adobe Research
-
-This work was supported by NSF grant 1453104.
-
-Paper link: arxiv.org/abs/2007.06833
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the “Software”), to deal with
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions: Redistributions of source code must
-retain the above copyright notice, this list of conditions and the following
-disclaimers. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimers in the
-documentation and/or other materials provided with the distribution. Neither
-the names of Computational Audio Group, University of Illinois at
-Urbana-Champaign, nor the names of its contributors may be used to endorse or
-promote products derived from this Software without specific prior written
-permission. THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
-EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
-OR OTHER DEALINGS WITH THE SOFTWARE.
-"""
-import torch
-import torch.nn as nn
-import math
-
 from ..filterbanks import make_enc_dec
-from ..masknn.norms import GlobLN
+from ..masknn import SuDORMRF, SuDORMRFImproved
+from .base_models import BaseTasNet
 
 
-class _BaseUBlock(nn.Module):
-    def __init__(self, out_chan=128, in_chan=512, upsampling_depth=4, use_globln=False):
-        super().__init__()
-        self.proj_1x1 = _ConvNormAct(
-            out_chan, in_chan, 1, stride=1, groups=1, use_globln=use_globln
-        )
-        self.depth = upsampling_depth
-        self.spp_dw = nn.ModuleList()
-        self.spp_dw.append(
-            _DilatedConvNorm(
-                in_chan, in_chan, kSize=5, stride=1, groups=in_chan, d=1, use_globln=use_globln,
-            )
-        )
-
-        for i in range(1, upsampling_depth):
-            if i == 0:
-                stride = 1
-            else:
-                stride = 2
-            self.spp_dw.append(
-                _DilatedConvNorm(
-                    in_chan,
-                    in_chan,
-                    kSize=2 * stride + 1,
-                    stride=stride,
-                    groups=in_chan,
-                    d=1,
-                    use_globln=use_globln,
-                )
-            )
-        if upsampling_depth > 1:
-            self.upsampler = torch.nn.Upsample(
-                scale_factor=2,
-                # align_corners=True,
-                # mode='bicubic'
-            )
-
-
-class UBlock(_BaseUBlock):
-    """ Upsampling block.
-
-    Based on the following principle:
-        ``REDUCE ---> SPLIT ---> TRANSFORM --> MERGE``
-    """
-
-    def __init__(self, out_chan=128, in_chan=512, upsampling_depth=4):
-        super().__init__(out_chan, in_chan, upsampling_depth, use_globln=False)
-        self.conv_1x1_exp = _ConvNorm(in_chan, out_chan, 1, 1, groups=1)
-        self.final_norm = _NormAct(in_chan)
-        self.module_act = _NormAct(out_chan)
-
-    def forward(self, x):
-        """
-        Args:
-            x: input feature map
-
-        Returns:
-            transformed feature map
-        """
-
-        # Reduce --> project high-dimensional feature maps to low-dimensional space
-        output1 = self.proj_1x1(x)
-        output = [self.spp_dw[0](output1)]
-
-        # Do the downsampling process from the previous level
-        for k in range(1, self.depth):
-            out_k = self.spp_dw[k](output[-1])
-            output.append(out_k)
-
-        # Gather them now in reverse order
-        for _ in range(self.depth - 1):
-            resampled_out_k = self.upsampler(output.pop(-1))
-            output[-1] = output[-1] + resampled_out_k
-
-        expanded = self.conv_1x1_exp(self.final_norm(output[-1]))
-
-        return self.module_act(expanded + x)
-
-
-class UConvBlock(_BaseUBlock):
-    """ Block which performs successive downsampling and upsampling
-    in order to be able to analyze the input features in multiple resolutions.
-    """
-
-    def __init__(self, out_chan=128, in_chan=512, upsampling_depth=4):
-        super().__init__(out_chan, in_chan, upsampling_depth, use_globln=True)
-        self.final_norm = _NormAct(in_chan, use_globln=True)
-        self.res_conv = nn.Conv1d(in_chan, out_chan, 1)
-
-    def forward(self, x):
-        """
-        Args
-            x: input feature map
-
-        Returns:
-            transformed feature map
-        """
-        residual = x.clone()
-        # Reduce --> project high-dimensional feature maps to low-dimensional space
-        output1 = self.proj_1x1(x)
-        output = [self.spp_dw[0](output1)]
-
-        # Do the downsampling process from the previous level
-        for k in range(1, self.depth):
-            out_k = self.spp_dw[k](output[-1])
-            output.append(out_k)
-
-        # Gather them now in reverse order
-        for _ in range(self.depth - 1):
-            resampled_out_k = self.upsampler(output.pop(-1))
-            output[-1] = output[-1] + resampled_out_k
-
-        expanded = self.final_norm(output[-1])
-
-        return self.res_conv(expanded) + residual
-
-
-class _SuDORMRFBase(nn.Module):
-    def __init__(
-        self,
-        out_chan=128,
-        in_chan=512,
-        num_blocks=16,
-        upsampling_depth=4,
-        kernel_size=21,
-        n_filters=512,
-        n_src=2,
-    ):
-        super().__init__()
-
-        # Number of sources to produce
-        self.in_chan = in_chan
-        self.out_chan = out_chan
-        self.num_blocks = num_blocks
-        self.upsampling_depth = upsampling_depth
-        self.kernel_size = kernel_size
-        self.n_filters = n_filters
-        self.n_src = n_src
-
-        # Appropriate padding is needed for arbitrary lengths
-        self.lcm = abs(self.kernel_size // 2 * 2 ** self.upsampling_depth) // math.gcd(
-            self.kernel_size // 2, 2 ** self.upsampling_depth
-        )
-
-    # Forward pass
-    def forward(self, input_wav):
-        x, s = self.frontend(input_wav)
-        x = self.separation(x)
-        return self.backend(x, s)
-
-    def separation(self, x):
-        raise NotImplementedError("Must be implemented in subclass")
-
-    def frontend(self, input_wav):
-        self.input_wav_shape = input_wav.shape
-        if input_wav.ndim == 2:
-            input_wav = input_wav.unsqueeze(1)
-
-        x = self.pad_to_appropriate_length(input_wav)
-        x = self.encoder(x)
-
-        # Split paths
-        s = x.clone().unsqueeze(1)
-
-        return x, s
-
-    def backend(self, x, s):
-        estimated_waveforms = self.decoder((x * s).view(x.shape[0], self.n_src, -1, x.shape[-1]))
-        # Remove padding
-        estimated_waveforms = estimated_waveforms[..., : self.input_wav_shape[-1]]
-        return estimated_waveforms
-
-    def pad_to_appropriate_length(self, x):
-        values_to_pad = int(x.shape[-1]) % self.lcm
-        if values_to_pad:
-            appropriate_shape = x.shape
-            padded_x = torch.zeros(
-                list(appropriate_shape[:-1]) + [appropriate_shape[-1] + self.lcm - values_to_pad],
-                dtype=torch.float32,
-            )
-            padded_x[..., : x.shape[-1]] = x
-            return padded_x
-        return x
-
-
-class SuDORMRF(_SuDORMRFBase):
+class SuDORMRFNet(BaseTasNet):
     """ SuDORMRF separation model, as described in [1].
 
     Args:
         n_src (int): Number of sources in the input mixtures.
-        out_chan (int, optional): Number of bins in the estimated masks.
-            If ``None``, `out_chan = in_chan`.
+        bn_chan (int, optional): Number of bins in the bottleneck layer and the UNet blocks.
+        num_blocks (int): Number of of UBlocks.
+        upsampling_depth (int): Depth of upsampling.
+        mask_act (str): Name of output activation.
         in_chan (int, optional): Number of input channels, should be equal to
             n_filters.
-        num_blocks (int): Number of of UBlocks
-        upsampling_depth (int): Depth of upsampling
         fb_name (str, className): Filterbank family from which to make encoder
             and decoder. To choose among [``'free'``, ``'analytic_free'``,
             ``'param_sinc'``, ``'stft'``].
@@ -255,10 +30,11 @@ class SuDORMRF(_SuDORMRFBase):
     def __init__(
         self,
         n_src,
-        out_chan=128,
-        in_chan=None,
+        bn_chan=128,
         num_blocks=16,
         upsampling_depth=4,
+        mask_act="softmax",
+        in_chan=None,
         fb_name="free",
         kernel_size=21,
         n_filters=512,
@@ -282,67 +58,28 @@ class SuDORMRF(_SuDORMRFBase):
                 "be the same. Received "
                 f"{n_feats} and {in_chan}"
             )
-        super().__init__(
-            out_chan, n_feats, num_blocks, upsampling_depth, kernel_size, n_feats, n_src,
+        masker = SuDORMRF(
+            n_feats,
+            n_src,
+            bn_chan=bn_chan,
+            num_blocks=num_blocks,
+            upsampling_depth=upsampling_depth,
+            mask_act=mask_act,
         )
-
-        # Front end
-        self.encoder = nn.Sequential(enc, nn.ReLU())
-
-        # Norm before the rest, and apply one more dense layer
-        self.ln = nn.GroupNorm(1, n_feats, eps=1e-08)
-        self.l1 = nn.Conv1d(n_feats, out_chan, kernel_size=1)
-
-        # Separation module
-        self.sm = nn.Sequential(
-            *[
-                UBlock(out_chan=out_chan, in_chan=in_chan, upsampling_depth=upsampling_depth,)
-                for _ in range(num_blocks)
-            ]
-        )
-
-        if out_chan != n_feats:
-            self.reshape_before_masks = nn.Conv1d(out_chan, n_feats, kernel_size=1)
-
-        # Masks layer
-        self.m = nn.Conv2d(
-            1, n_src, kernel_size=(n_feats + 1, 1), padding=(n_feats - n_feats // 2, 0),
-        )
-
-        # Back end
-        self.decoder = dec
-        self.ln_mask_in = nn.GroupNorm(1, n_feats, eps=1e-08)
-
-    def separation(self, x):
-        x = self.ln(x)
-        x = self.l1(x)
-        x = self.sm(x)
-
-        if self.out_chan != self.n_filters:
-            # x = self.ln_bef_out_reshape(x)
-            x = self.reshape_before_masks(x)
-
-        # Get masks and apply them
-        x = self.m(x.unsqueeze(1))
-        if self.n_src == 1:
-            x = torch.sigmoid(x)
-        else:
-            x = nn.functional.softmax(x, dim=1)
-
-        return x
+        super().__init__(enc, masker, dec, encoder_activation="relu")
 
 
-class SuDORMRFImproved(_SuDORMRFBase):
+class SuDORMRFImprovedNet(BaseTasNet):
     """ Improved SuDORMRF separation model, as described in [1].
 
     Args:
         n_src (int): Number of sources in the input mixtures.
-        out_chan (int, optional): Number of bins in the estimated masks.
-            If ``None``, `out_chan = in_chan`.
+        bn_chan (int, optional): Number of bins in the bottleneck layer and the UNet blocks.
+        num_blocks (int): Number of of UBlocks.
+        upsampling_depth (int): Depth of upsampling.
+        mask_act (str): Name of output activation.
         in_chan (int, optional): Number of input channels, should be equal to
             n_filters.
-        num_blocks (int): Number of of UBlocks
-        upsampling_depth (int): Depth of upsampling
         fb_name (str, className): Filterbank family from which to make encoder
             and decoder. To choose among [``'free'``, ``'analytic_free'``,
             ``'param_sinc'``, ``'stft'``].
@@ -359,15 +96,17 @@ class SuDORMRFImproved(_SuDORMRFBase):
     def __init__(
         self,
         n_src,
-        out_chan=128,
-        in_chan=512,
+        bn_chan=128,
         num_blocks=16,
         upsampling_depth=4,
+        mask_act="relu",
+        in_chan=None,
         fb_name="free",
         kernel_size=21,
         n_filters=512,
         **fb_kwargs,
     ):
+
         # Need the encoder to determine the number of input channels
         enc, dec = make_enc_dec(
             fb_name,
@@ -386,147 +125,12 @@ class SuDORMRFImproved(_SuDORMRFBase):
                 "be the same. Received "
                 f"{n_feats} and {in_chan}"
             )
-        super().__init__(
-            out_chan, n_feats, num_blocks, upsampling_depth, kernel_size, n_feats, n_src,
+        masker = SuDORMRFImproved(
+            n_feats,
+            n_src,
+            bn_chan=bn_chan,
+            num_blocks=num_blocks,
+            upsampling_depth=upsampling_depth,
+            mask_act=mask_act,
         )
-        # Front end
-        self.encoder = enc
-        if fb_name in ["free", "analytic_free"]:
-            torch.nn.init.xavier_uniform_(self.encoder.filterbank._filters)
-
-        # Norm before the rest, and apply one more dense layer
-        self.ln = GlobLN(n_feats)
-        self.bottleneck = nn.Conv1d(n_feats, out_chan, kernel_size=1)
-
-        # Separation module
-        self.sm = nn.Sequential(
-            *[
-                UConvBlock(out_chan=out_chan, in_chan=in_chan, upsampling_depth=upsampling_depth,)
-                for _ in range(num_blocks)
-            ]
-        )
-
-        mask_conv = nn.Conv1d(out_chan, n_src * n_feats, 1)
-        self.mask_net = nn.Sequential(nn.PReLU(), mask_conv)
-
-        # Back end
-        self.decoder = dec
-        if fb_name in ["free", "analytic_free"]:
-            torch.nn.init.xavier_uniform_(self.decoder.filterbank._filters)
-        self.mask_nl_class = nn.ReLU()
-
-    def separation(self, x):
-        x = self.ln(x)
-        x = self.bottleneck(x)
-        x = self.sm(x)
-
-        x = self.mask_net(x)
-        x = x.view(x.shape[0], self.n_src, self.n_filters, -1)
-        x = self.mask_nl_class(x)
-        return x
-
-
-class _ConvNormAct(nn.Module):
-    """ Convolution layer with normalization and a PReLU activation.
-
-    Args
-        nIn: number of input channels
-        nOut: number of output channels
-        kSize: kernel size
-        stride: stride rate for down-sampling. Default is 1
-    """
-
-    def __init__(self, nIn, nOut, kSize, stride=1, groups=1, use_globln=False):
-
-        super().__init__()
-        padding = int((kSize - 1) / 2)
-        self.conv = nn.Conv1d(
-            nIn, nOut, kSize, stride=stride, padding=padding, bias=True, groups=groups
-        )
-        if use_globln:
-            self.norm = GlobLN(nOut)
-            self.act = nn.PReLU()
-        else:
-            self.norm = nn.GroupNorm(1, nOut, eps=1e-08)
-            self.act = nn.PReLU(nOut)
-
-    def forward(self, inp):
-        output = self.conv(inp)
-        output = self.norm(output)
-        return self.act(output)
-
-
-class _ConvNorm(nn.Module):
-    """ Convolution layer with normalization without activation.
-
-    Args:
-        nIn: number of input channels
-        nOut: number of output channels
-        kSize: kernel size
-        stride: stride rate for down-sampling. Default is 1
-    """
-
-    def __init__(self, nIn, nOut, kSize, stride=1, groups=1):
-
-        super().__init__()
-        padding = int((kSize - 1) / 2)
-        self.conv = nn.Conv1d(
-            nIn, nOut, kSize, stride=stride, padding=padding, bias=True, groups=groups
-        )
-        self.norm = nn.GroupNorm(1, nOut, eps=1e-08)
-
-    def forward(self, inp):
-        output = self.conv(inp)
-        return self.norm(output)
-
-
-class _NormAct(nn.Module):
-    """ Normalization and PReLU activation.
-
-    Args:
-         nOut: number of output channels
-    """
-
-    def __init__(self, nOut, use_globln=False):
-        super().__init__()
-        if use_globln:
-            self.norm = GlobLN(nOut)
-        else:
-            self.norm = nn.GroupNorm(1, nOut, eps=1e-08)
-        self.act = nn.PReLU(nOut)
-
-    def forward(self, inp):
-        output = self.norm(inp)
-        return self.act(output)
-
-
-class _DilatedConvNorm(nn.Module):
-    """ Dilated convolution with normalized output.
-
-    Args:
-        nIn: number of input channels
-        nOut: number of output channels
-        kSize: kernel size
-        stride: optional stride rate for down-sampling
-        d: optional dilation rate
-    """
-
-    def __init__(self, nIn, nOut, kSize, stride=1, d=1, groups=1, use_globln=False):
-        super().__init__()
-        self.conv = nn.Conv1d(
-            nIn,
-            nOut,
-            kSize,
-            stride=stride,
-            dilation=d,
-            padding=((kSize - 1) // 2) * d,
-            groups=groups,
-        )
-        if use_globln:
-            self.norm = GlobLN(nOut)
-        else:
-            self.norm = nn.GroupNorm(1, nOut, eps=1e-08)
-
-    def forward(self, inp):
-        output = self.conv(inp)
-        return self.norm(output)
+        super().__init__(enc, masker, dec, encoder_activation=None)

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -69,7 +69,7 @@ def test_save_and_load_dprnn(fb):
 
 def test_sudormrf():
     model = SuDORMRFNet(
-        2, bn_chan=10, num_blocks=4, upsampling_depth=2, kernel_size=21, n_filters=10,
+        2, bn_chan=10, num_blocks=4, upsampling_depth=2, kernel_size=21, n_filters=12,
     )
     test_input = torch.randn(1, 801)
     model_conf = model.serialize()
@@ -80,7 +80,7 @@ def test_sudormrf():
 
 def test_sudormrf_imp():
     model = SuDORMRFImprovedNet(
-        2, bn_chan=10, num_blocks=4, upsampling_depth=2, n_filters=10, kernel_size=21,
+        2, bn_chan=10, num_blocks=4, upsampling_depth=2, kernel_size=21, n_filters=12,
     )
     test_input = torch.randn(1, 801)
     model_conf = model.serialize()

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -4,7 +4,7 @@ from torch.testing import assert_allclose
 import numpy as np
 import soundfile as sf
 from asteroid.models import ConvTasNet, DPRNNTasNet, DPTNet
-from asteroid.models import SuDORMRF, SuDORMRFImproved
+from asteroid.models import SuDORMRFNet, SuDORMRFImprovedNet
 
 
 def test_convtasnet_sep():
@@ -68,7 +68,7 @@ def test_save_and_load_dprnn(fb):
 
 
 def test_sudormrf():
-    model = SuDORMRF(
+    model = SuDORMRFNet(
         2, out_chan=10, in_chan=10, num_blocks=4, upsampling_depth=2, kernel_size=21, n_filters=10,
     )
     test_input = torch.randn(1, 801)
@@ -76,7 +76,7 @@ def test_sudormrf():
 
 
 def test_sudormrf_imp():
-    model = SuDORMRFImproved(
+    model = SuDORMRFImprovedNet(
         2, out_chan=10, in_chan=10, num_blocks=4, upsampling_depth=2, n_filters=10, kernel_size=21,
     )
     test_input = torch.randn(1, 801)

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -69,18 +69,24 @@ def test_save_and_load_dprnn(fb):
 
 def test_sudormrf():
     model = SuDORMRFNet(
-        2, out_chan=10, in_chan=10, num_blocks=4, upsampling_depth=2, kernel_size=21, n_filters=10,
+        2, bn_chan=10, num_blocks=4, upsampling_depth=2, kernel_size=21, n_filters=10,
     )
     test_input = torch.randn(1, 801)
-    model(test_input)
+    model_conf = model.serialize()
+
+    reconstructed_model = SuDORMRFNet.from_pretrained(model_conf)
+    assert_allclose(model.separate(test_input), reconstructed_model(test_input))
 
 
 def test_sudormrf_imp():
     model = SuDORMRFImprovedNet(
-        2, out_chan=10, in_chan=10, num_blocks=4, upsampling_depth=2, n_filters=10, kernel_size=21,
+        2, bn_chan=10, num_blocks=4, upsampling_depth=2, n_filters=10, kernel_size=21,
     )
     test_input = torch.randn(1, 801)
-    model(test_input)
+    model_conf = model.serialize()
+
+    reconstructed_model = SuDORMRFImprovedNet.from_pretrained(model_conf)
+    assert_allclose(model.separate(test_input), reconstructed_model(test_input))
 
 
 def test_dptnet():


### PR DESCRIPTION
Split SuDORMRF architectures in encoder/masker/decoder instead of the current design where things are entangled and the separator network cannot be used on custom features. 

#### Few advantages:
- More modular -> Separator networks can be used outside asteroid. 
- Fit in encoder/masker/decoder architecture -> Inherit from `BaseTasNet` -> pretrained models OK.

#### Notes
- Small blocks are stored in masknn/_local.py and are private. 
- Added support for "all" activation functions for the output mask.
- No support for custom number of output bins (renamed `out_chan` by `bn_chan` because it was the inner dimension of the Ublocks, but it suggested otherwise). Adding support for it would be quite easy, should I do it?  

@etzinis would like to review? 