### PR TITLE
[src & tests] Add LSTMTasNet to serializable models 

### DIFF
--- a/asteroid/__init__.py
+++ b/asteroid/__init__.py
@@ -1,6 +1,6 @@
 import pathlib
 from .utils import deprecation_utils, torch_utils  # noqa
-from .models import ConvTasNet, DPRNNTasNet, DPTNet
+from .models import ConvTasNet, DPRNNTasNet, DPTNet, LSTMTasNet
 
 project_root = str(pathlib.Path(__file__).expanduser().absolute().parent.parent)
 __version__ = "0.3.0"

--- a/asteroid/masknn/__init__.py
+++ b/asteroid/masknn/__init__.py
@@ -1,9 +1,10 @@
 from .convolutional import TDConvNet
-from .recurrent import DPRNN
+from .recurrent import DPRNN, LSTMMasker
 from .attention import DPTransformer
 
 __all__ = [
     "TDConvNet",
     "DPRNN",
     "DPTransformer",
+    "LSTMMasker",
 ]

--- a/asteroid/masknn/recurrent.py
+++ b/asteroid/masknn/recurrent.py
@@ -3,7 +3,7 @@ from torch import nn
 from torch.nn.functional import fold, unfold
 
 from . import norms, activations
-from .norms import GlobLN
+from .norms import GlobLN, CumLN
 from ..utils import has_arg
 
 
@@ -447,7 +447,10 @@ class LSTMMasker(nn.Module):
 
         # Create TasNet masker
         out_size = hid_size * (int(bidirectional) + 1)
-        self.bn_layer = GlobLN(in_chan)
+        if bidirectional:
+            self.bn_layer = GlobLN(in_chan)
+        else:
+            self.bn_layer = CumLN(in_chan)
         self.masker = nn.Sequential(
             SingleRNN(
                 "lstm",

--- a/asteroid/masknn/recurrent.py
+++ b/asteroid/masknn/recurrent.py
@@ -3,6 +3,7 @@ from torch import nn
 from torch.nn.functional import fold, unfold
 
 from . import norms, activations
+from .norms import GlobLN
 from ..utils import has_arg
 
 
@@ -387,5 +388,96 @@ class DPRNN(nn.Module):
             "rnn_type": self.rnn_type,
             "num_layers": self.num_layers,
             "dropout": self.dropout,
+        }
+        return config
+
+
+class LSTMMasker(nn.Module):
+    """ LSTM mask network introduced in [1], without skip connections.
+
+    Args:
+        in_chan (int): Number of input filters.
+        n_src (int): Number of masks to estimate.
+        out_chan  (int or None): Number of bins in the estimated masks.
+            Defaults to `in_chan`.
+        rnn_type (str, optional): Type of RNN used. Choose between ``'RNN'``,
+            ``'LSTM'`` and ``'GRU'``.
+        n_layers (int, optional): Number of layers in each RNN.
+        hid_size (int): Number of neurons in the RNNs cell state.
+        mask_act (str, optional): Which non-linear function to generate mask.
+        bidirectional (bool, optional): Whether to use BiLSTM
+        dropout (float, optional): Dropout ratio, must be in [0,1].
+
+    References:
+        [1]: Yi Luo et al. "Real-time Single-channel Dereverberation and Separation
+            with Time-domain Audio Separation Network", Interspeech 2018
+    """
+
+    def __init__(
+        self,
+        in_chan,
+        n_src,
+        out_chan=None,
+        rnn_type="lstm",
+        n_layers=4,
+        hid_size=512,
+        dropout=0.3,
+        mask_act="sigmoid",
+        bidirectional=True,
+    ):
+        super().__init__()
+        self.in_chan = in_chan
+        self.n_src = n_src
+        out_chan = out_chan if out_chan is not None else in_chan
+        self.out_chan = out_chan
+        self.rnn_type = rnn_type
+        self.n_layers = n_layers
+        self.hid_size = hid_size
+        self.dropout = dropout
+        self.mask_act = mask_act
+        self.bidirectional = bidirectional
+
+        # Get activation function.
+        mask_nl_class = activations.get(mask_act)
+        # For softmax, feed the source dimension.
+        if has_arg(mask_nl_class, "dim"):
+            self.output_act = mask_nl_class(dim=1)
+        else:
+            self.output_act = mask_nl_class()
+
+        # Create TasNet masker
+        out_size = hid_size * (int(bidirectional) + 1)
+        self.bn_layer = GlobLN(in_chan)
+        self.masker = nn.Sequential(
+            SingleRNN(
+                "lstm",
+                in_chan,
+                hidden_size=hid_size,
+                n_layers=n_layers,
+                bidirectional=bidirectional,
+                dropout=dropout,
+            ),
+            nn.Linear(out_size, self.n_src * out_chan),
+            self.output_act,
+        )
+
+    def forward(self, x):
+        batch_size = x.shape[0]
+        to_sep = self.bn_layer(x)
+        est_masks = self.masker(to_sep.transpose(-1, -2)).transpose(-1, -2)
+        est_masks = est_masks.view(batch_size, self.n_src, self.out_chan, -1)
+        return est_masks
+
+    def get_config(self):
+        config = {
+            "in_chan": self.in_chan,
+            "n_src": self.n_src,
+            "out_chan": self.out_chan,
+            "rnn_type": self.rnn_type,
+            "n_layers": self.n_layers,
+            "hid_size": self.hid_size,
+            "dropout": self.dropout,
+            "mask_act": self.mask_act,
+            "bidirectional": self.bidirectional,
         }
         return config

--- a/asteroid/models/__init__.py
+++ b/asteroid/models/__init__.py
@@ -3,6 +3,7 @@ from .conv_tasnet import ConvTasNet
 from .dprnn_tasnet import DPRNNTasNet
 from .sudormrf import SuDORMRFImproved, SuDORMRF
 from .dptnet import DPTNet
+from .lstm_tasnet import LSTMTasNet
 
 # Sharing-related
 from .publisher import save_publishable, upload_publishable
@@ -13,6 +14,7 @@ __all__ = [
     "SuDORMRFImproved",
     "SuDORMRF",
     "DPTNet",
+    "LSTMTasNet",
     "save_publishable",
     "upload_publishable",
 ]

--- a/asteroid/models/lstm_tasnet.py
+++ b/asteroid/models/lstm_tasnet.py
@@ -1,0 +1,103 @@
+import torch
+from torch import nn
+from copy import deepcopy
+
+from ..filterbanks import make_enc_dec
+from ..masknn import LSTMMasker
+from .base_models import BaseTasNet
+
+
+class LSTMTasNet(BaseTasNet):
+    """ TasNet separation model, as described in [1].
+
+    Args:
+        n_src (int): Number of masks to estimate.
+        out_chan  (int or None): Number of bins in the estimated masks.
+            Defaults to `in_chan`.
+        hid_size (int): Number of neurons in the RNNs cell state.
+            Defaults to 128.
+        mask_act (str, optional): Which non-linear function to generate mask.
+        bidirectional (bool, optional): True for bidirectional Inter-Chunk RNN
+            (Intra-Chunk is always bidirectional).
+        rnn_type (str, optional): Type of RNN used. Choose between ``'RNN'``,
+            ``'LSTM'`` and ``'GRU'``.
+        n_layers (int, optional): Number of layers in each RNN.
+        dropout (float, optional): Dropout ratio, must be in [0,1].
+        in_chan (int, optional): Number of input channels, should be equal to
+            n_filters.
+        fb_name (str, className): Filterbank family from which to make encoder
+            and decoder. To choose among [``'free'``, ``'analytic_free'``,
+            ``'param_sinc'``, ``'stft'``].
+        n_filters (int): Number of filters / Input dimension of the masker net.
+        kernel_size (int): Length of the filters.
+        stride (int, optional): Stride of the convolution.
+            If None (default), set to ``kernel_size // 2``.
+        **fb_kwargs (dict): Additional kwards to pass to the filterbank
+            creation.
+
+    References:
+        [1]: Yi Luo et al. "Real-time Single-channel Dereverberation and Separation
+            with Time-domain Audio Separation Network", Interspeech 2018
+    """
+
+    def __init__(
+        self,
+        n_src,
+        out_chan=None,
+        rnn_type="lstm",
+        n_layers=4,
+        hid_size=512,
+        dropout=0.3,
+        mask_act="sigmoid",
+        bidirectional=True,
+        in_chan=None,
+        fb_name="free",
+        n_filters=64,
+        kernel_size=16,
+        stride=8,
+        encoder_activation=None,
+        **fb_kwargs,
+    ):
+        encoder, decoder = make_enc_dec(
+            fb_name, kernel_size=kernel_size, n_filters=n_filters, stride=stride, **fb_kwargs
+        )
+        n_feats = encoder.n_feats_out
+        if in_chan is not None:
+            assert in_chan == n_feats, (
+                "Number of filterbank output channels"
+                " and number of input channels should "
+                "be the same. Received "
+                f"{n_feats} and {in_chan}"
+            )
+
+        # Real gated encoder
+        encoder = _GatedEncoder(encoder)
+
+        # Masker
+        masker = LSTMMasker(
+            n_feats,
+            n_src,
+            out_chan=out_chan,
+            hid_size=hid_size,
+            mask_act=mask_act,
+            bidirectional=bidirectional,
+            rnn_type=rnn_type,
+            n_layers=n_layers,
+            dropout=dropout,
+        )
+        super().__init__(encoder, masker, decoder, encoder_activation=encoder_activation)
+
+
+class _GatedEncoder(nn.Module):
+    def __init__(self, encoder):
+        super().__init__()
+        # For config
+        self.filterbank = encoder.filterbank
+        # Gated encoder.
+        self.encoder_relu = encoder
+        self.encoder_sig = deepcopy(encoder)
+
+    def forward(self, x):
+        relu_out = torch.relu(self.encoder_relu(x))
+        sig_out = torch.sigmoid(self.encoder_sig(x))
+        return sig_out * relu_out

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,4 +25,3 @@ coverage run --source asteroid -m py.test tests -v --doctest-modules
 # print coverage stats
 coverage report -m
 ```
-

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -3,7 +3,7 @@ import pytest
 from torch.testing import assert_allclose
 import numpy as np
 import soundfile as sf
-from asteroid.models import ConvTasNet, DPRNNTasNet, DPTNet
+from asteroid.models import ConvTasNet, DPRNNTasNet, DPTNet, LSTMTasNet
 from asteroid.models import SuDORMRF, SuDORMRFImproved
 
 
@@ -64,6 +64,16 @@ def test_save_and_load_dprnn(fb):
     model_conf = model1.serialize()
 
     reconstructed_model = DPRNNTasNet.from_pretrained(model_conf)
+    assert_allclose(model1.separate(test_input), reconstructed_model(test_input))
+
+
+@pytest.mark.parametrize("fb", ["free", "stft", "analytic_free", "param_sinc"])
+def test_save_and_load_tasnet(fb):
+    model1 = LSTMTasNet(n_src=2, hid_size=4, n_layers=1, n_filters=32, dropout=0.0, fb_name=fb,)
+    test_input = torch.randn(1, 800)
+    model_conf = model1.serialize()
+
+    reconstructed_model = LSTMTasNet.from_pretrained(model_conf)
     assert_allclose(model1.separate(test_input), reconstructed_model(test_input))
 
 


### PR DESCRIPTION
The implementation is not absolutely faithful to the original article. 

#### Notable differences
- No per-segment L2 normalization/rescaling
- No skip connection in stacked LSTM
- GlobLN used as "bottleneck layer"
- Stride support. 

@popcornell does this sound reasonable to you? 
This is the implementation we used in the Asteroid paper on the WHAM and WHAMR dataset.  