### PR TITLE
[tests & CI] Fix tests for publishing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,9 +7,6 @@ exclude_lines =
 
 omit =
   asteroid/data/*
-  # Need ACCESS_TOKEN, not possible from fork.
-  asteroid/models/publisher.py
-  asteroid/models/zenodo.py
 
 [run]
 source=asteroid

--- a/.github/workflows/test_asteroid_package.yml
+++ b/.github/workflows/test_asteroid_package.yml
@@ -39,25 +39,26 @@ jobs:
 
     - name: Source code tests
       run: |
-        coverage run -m py.test tests  --ignore tests/models/publish_test.py
-        coverage xml -o coverage_tests.xml
+        coverage run -a -m py.test tests  --ignore tests/models/publish_test.py
+#        coverage xml -o coverage_tests.xml
 #        bash <(curl -s https://codecov.io/bash)
 
     # This tends to fail despite the code works, when Zenodo is slow.
     - name: Model-sharing tests
       # coverage run -a appends cov data to .coverage
       run: |
-        coverage run -m py.test tests/models/publish_test.py
-        coverage xml -o coverage_publish.xml
+        coverage run -a -m py.test tests/models/publish_test.py
       env: #Access token as an env variable
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
     - name: Coverage report
       run: |
         coverage report -m
+        coverage xml -o coverage.xml
 #        coverage combine .coverage_main .coverage_pub
 
     - name: Codecov upload
       uses: codecov/codecov-action@v1
       with:
-        files: ./coverage_tests.xml, ./coverage_publish.xml
+        file: ./coverage.xml
+#        files: ./coverage_tests.xml, ./coverage_publish.xml

--- a/.github/workflows/test_asteroid_package.yml
+++ b/.github/workflows/test_asteroid_package.yml
@@ -40,25 +40,20 @@ jobs:
     - name: Source code tests
       run: |
         coverage run -a -m py.test tests  --ignore tests/models/publish_test.py
-#        coverage xml -o coverage_tests.xml
-#        bash <(curl -s https://codecov.io/bash)
 
     # This tends to fail despite the code works, when Zenodo is slow.
     - name: Model-sharing tests
-      # coverage run -a appends cov data to .coverage
       run: |
         coverage run -a -m py.test tests/models/publish_test.py
-      env: #Access token as an env variable
+      env:  # Access token as an env variable
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
     - name: Coverage report
       run: |
         coverage report -m
         coverage xml -o coverage.xml
-#        coverage combine .coverage_main .coverage_pub
 
     - name: Codecov upload
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml
-#        files: ./coverage_tests.xml, ./coverage_publish.xml

--- a/.github/workflows/test_asteroid_package.yml
+++ b/.github/workflows/test_asteroid_package.yml
@@ -37,28 +37,27 @@ jobs:
         python -m pip list
       shell: bash
 
-    - name: Pytest and coverage
+    - name: Source code tests
       run: |
         coverage run -m py.test tests  --ignore tests/models/publish_test.py
-        coverage report -m
-        coverage xml
-        bash <(curl -s https://codecov.io/bash)
-#      env: #Access token as an env variable
-#        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        coverage xml -o coverage_tests.xml
+#        bash <(curl -s https://codecov.io/bash)
 
     # This tends to fail despite the code works, when Zenodo is slow.
-#    - name: Pytest and coverage (Model-sharing only)
-#      # coverage run -a appends cov data to .coverage
-#      run: |
-#        coverage run -m py.test tests/models/publish_test.py
-#        coverage xml -o coverage_publish.xml
+    - name: Model-sharing tests
+      # coverage run -a appends cov data to .coverage
+      run: |
+        coverage run -m py.test tests/models/publish_test.py
+        coverage xml -o coverage_publish.xml
+      env: #Access token as an env variable
+        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
-#    - name: Coverage report
-#      run: |
+    - name: Coverage report
+      run: |
+        coverage report -m
 #        coverage combine .coverage_main .coverage_pub
-#        coverage report -m
 
-#    - name: Codecov upload
-#      uses: codecov/codecov-action@v1
-#      with:
-#        files: ./coverage_tests.xml, ./coverage_publish.xml
+    - name: Codecov upload
+      uses: codecov/codecov-action@v1
+      with:
+        files: ./coverage_tests.xml, ./coverage_publish.xml

--- a/tests/models/publish_test.py
+++ b/tests/models/publish_test.py
@@ -42,6 +42,7 @@ def test_upload():
             affiliation="INRIA",
             use_sandbox=True,
             unit_test=True,  # Remove this argument and monkeypatch `input()`
+            git_username="mpariente",
         )
 
         # Assert metadata is correct


### PR DESCRIPTION
Publishing tests requires an `ACCESS_TOKEN` for Zenodo's sandbox. 
This can be set as a secret in the repo, but forks won't have it, so it will be skipped in PRs. 

Also, because this test can fail often, or take too much time, we'd like to isolate it in a separate step to easily see if this is the one failing. 