### PR TITLE
DCUNet and DCCRNet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.2.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
       - id: black
         types: [python]

--- a/asteroid/__init__.py
+++ b/asteroid/__init__.py
@@ -1,6 +1,7 @@
 import pathlib
+
+from .models import ConvTasNet, DCCRNet, DCUNet, DPRNNTasNet, DPTNet, LSTMTasNet, DeMask
 from .utils import deprecation_utils, torch_utils  # noqa
-from .models import ConvTasNet, DPRNNTasNet, DPTNet, LSTMTasNet, DeMask
 
 project_root = str(pathlib.Path(__file__).expanduser().absolute().parent.parent)
 __version__ = "0.3.3"
@@ -18,5 +19,7 @@ __all__ = [
     "DPTNet",
     "LSTMTasNet",
     "DeMask",
+    "DCUNet",
+    "DCCRNet",
     "show_available_models",
 ]

--- a/asteroid/complex_nn.py
+++ b/asteroid/complex_nn.py
@@ -1,0 +1,178 @@
+"""Complex building blocks that work with _PyTorch native_ complex tensors, i.e.
+dtypes complex64/complex128, or tensors for which `.is_complex()` returns True.
+
+Note that Asteroid code has two other representations of complex numbers:
+
+- Torchaudio representation [..., 2] where [..., 0] and [..., 1] are real and
+  imaginary components, respectively
+- Asteroid style representation, identical to the Torchaudio representation, but
+  with the last dimension concatenated: tensor([r1, r2, ..., rn, i1, i2, ..., in]).
+  The concatenated (2 * n) dimension may be at an arbitrary position, i.e. the tensor
+  is of shape [..., 2 * n, ...].  See `asteroid.filterbanks.transforms` for details.
+"""
+import functools
+import torch
+import torchaudio
+from torch import nn
+from asteroid.filterbanks import transforms
+
+
+# Alias to denote PyTorch native complex tensor (complex64/complex128).
+# `.is_complex()` returns True on these tensors.
+ComplexTensor = torch.Tensor
+
+
+def is_torch_complex(x):
+    return x.is_complex()
+
+
+def torch_complex_from_magphase(mag, phase):
+    return as_torch_complex((mag * torch.cos(phase), mag * torch.sin(phase)))
+
+
+def as_torch_complex(x, asteroid_dim=-2):
+    """Convert complex `x` to complex. Input may be one of:
+
+    - PyTorch native complex
+    - Torchaudio style complex
+    - Asteroid style complex
+    - Tuple or list of (real, imaginary) components
+
+    Args:
+        asteroid_dim (int, optional): Dimension to check for Asteroid-style complex.
+
+    :Raises:
+        ValueError: If type of `x` is not understood.
+    """
+    if isinstance(x, (list, tuple)) and len(x) == 2:
+        return torch.view_as_complex(torch.stack(x, dim=-1))
+    elif is_torch_complex(x):
+        return x
+    else:
+        is_torchaudio_complex = transforms.is_torchaudio_complex(x)
+        is_asteroid_complex = transforms.is_asteroid_complex(x, asteroid_dim)
+        if is_torchaudio_complex and is_asteroid_complex:
+            raise ValueError(
+                f"Tensor of shape {x.shape} is both a valid Torchaudio-style and "
+                "Asteroid-style complex. PyTorch complex conversion is ambiguous."
+            )
+        elif is_torchaudio_complex:
+            return torch.view_as_complex(x)
+        elif is_asteroid_complex:
+            return torch.view_as_complex(transforms.to_torchaudio(x, asteroid_dim))
+        else:
+            raise ValueError(
+                f"Do not know how to convert tensor of shape {x.shape}, dtype={x.dtype} to complex"
+            )
+
+
+def on_reim(f):
+    """Make a complex-valued function callable from a real-valued one by applying it to
+    the real and imaginary components independently.
+
+    :Return:
+        cf(x), complex version of `f`: A function that applies `f` to the real and
+        imaginary components of `x` and returns the result as PyTorch complex tensor.
+    """
+
+    @functools.wraps(f)
+    def cf(x):
+        return as_torch_complex((f(x.real), f(x.imag)))
+
+    # functools.wraps keeps the original name of `f`, which might be confusing,
+    # since we are creating a new function that behaves differently.
+    # Both __name__ and __qualname__ are used by printing code.
+    cf.__name__ == f"{f.__name__} (complex)"
+    cf.__qualname__ == f"{f.__qualname__} (complex)"
+    return cf
+
+
+class OnReIm(nn.Module):
+    """Like `on_reim`, but for stateful modules.
+
+    Args:
+        module_cls (callable): A class or function that returns a Torch module/functional.
+            Called 2x with *args, **kwargs, to construct the real and imaginary component modules.
+    """
+
+    def __init__(self, module_cls, *args, **kwargs):
+        super().__init__()
+        self.re_module = module_cls(*args, **kwargs)
+        self.im_module = module_cls(*args, **kwargs)
+
+    def forward(self, x):
+        return as_torch_complex((self.re_module(x.real), self.im_module(x.imag)))
+
+
+class ComplexMultiplicationWrapper(nn.Module):
+    """Make a complex-valued module `F` from a real-valued module `f` by applying
+    complex multiplication rules:
+
+        F(a + i b) = f1(a) - f1(b) + i (f2(b) + f2(a))
+
+    where `f1`, `f2` are instances of `f` that do *not* share weights.
+
+    Args:
+        module_cls (callable): A class or function that returns a Torch module/functional.
+            Constructor of `f` in the formula above.  Called 2x with *args, **kwargs,
+            to construct the real and imaginary component modules.
+    """
+
+    def __init__(self, module_cls, *args, **kwargs):
+        super().__init__()
+        self.re_module = module_cls(*args, **kwargs)
+        self.im_module = module_cls(*args, **kwargs)
+
+    def forward(self, x: ComplexTensor) -> ComplexTensor:
+        return as_torch_complex(
+            (
+                self.re_module(x.real) - self.im_module(x.imag),
+                self.re_module(x.imag) + self.im_module(x.real),
+            )
+        )
+
+
+ComplexConv2d = functools.partial(ComplexMultiplicationWrapper, nn.Conv2d)
+ComplexConvTranspose2d = functools.partial(ComplexMultiplicationWrapper, nn.ConvTranspose2d)
+
+
+class BoundComplexMask(nn.Module):
+    """Module version of `bound_complex_mask`"""
+
+    def __init__(self, bound_type):
+        super().__init__()
+        self.bound_type = bound_type
+
+    def forward(self, mask: ComplexTensor):
+        return bound_complex_mask(mask, self.bound_type)
+
+
+def bound_complex_mask(mask: ComplexTensor, bound_type="tanh"):
+    r"""Bound a complex mask, as proposed in [1], section 3.2.
+
+    Valid bound types, for a complex mask $M = |M| ⋅ e^{i φ(M)}$:
+
+    - Unbounded ("UBD"): $M_{\mathrm{UBD}} = M$
+    - Sigmoid ("BDSS"): $M_{\mathrm{BDSS}} = σ(|M|) e^{i σ(φ(M))}$
+    - Tanh ("BDT"): $M_{\mathrm{BDT}} = \mathrm{tanh}(|M|) e^{i φ(M)}$
+
+    Args:
+        bound_type (str or None): The type of bound to use, either of
+            "tanh"/"bdt" (default), "sigmoid"/"bdss" or None/"bdt".
+
+    References:
+        [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
+        Hyeong-Seok Choi et al.
+        https://arxiv.org/abs/1903.03107
+    """
+    if bound_type in {"BDSS", "sigmoid"}:
+        return on_reim(torch.sigmoid)(mask)
+    elif bound_type in {"BDT", "tanh", "UBD", None}:
+        mask_mag, mask_phase = torchaudio.functional.magphase(torch.view_as_real(mask))
+        if bound_type in {"BDT", "tanh"}:
+            mask_mag_bounded = torch.tanh(mask_mag)
+        else:
+            mask_mag_bounded = mask_mag
+        return torch_complex_from_magphase(mask_mag_bounded, mask_phase)
+    else:
+        raise ValueError(f"Unknown mask bound {bound_type}")

--- a/asteroid/filterbanks/transforms.py
+++ b/asteroid/filterbanks/transforms.py
@@ -177,8 +177,23 @@ def apply_complex_mask(tf_rep, mask, dim=-2):
     return mul_c(tf_rep, mask, dim=dim)
 
 
+def is_asteroid_complex(tensor, dim=-2):
+    """Check if tensor is complex-like in a given dimension.
+
+    Args:
+        tensor (torch.Tensor): tensor to be checked.
+        dim(int): the frequency (or equivalent) dimension along which
+            real and imaginary values are concatenated.
+
+    Returns:
+        True if dimension is even in the specified dimension, otherwise False
+
+    """
+    return tensor.shape[dim] % 2 == 0
+
+
 def check_complex(tensor, dim=-2):
-    """Assert tensor in complex-like in a given dimension.
+    """Assert that tensor is an Asteroid-style complex in a given dimension.
 
     Args:
         tensor (torch.Tensor): tensor to be checked.
@@ -189,10 +204,10 @@ def check_complex(tensor, dim=-2):
         AssertionError if dimension is not even in the specified dimension
 
     """
-    if tensor.shape[dim] % 2 != 0:
+    if not is_asteroid_complex(tensor, dim):
         raise AssertionError(
-            "Could not equally chunk the tensor (shape {}) "
-            "along the given dimension ({}). Dim axis is "
+            f"Could not equally chunk the tensor (shape {tensor.shape}) "
+            f"along the given dimension ({dim}). Dim axis is "
             "probably wrong"
         )
 
@@ -228,6 +243,34 @@ def from_numpy(array, dim=-2):
     import numpy as np  # Hub-importable
 
     return torch.cat([torch.from_numpy(np.real(array)), torch.from_numpy(np.imag(array))], dim=dim)
+
+
+def is_torchaudio_complex(x):
+    """Check if tensor is Torchaudio-style complex-like (last dimension is 2).
+
+    Args:
+        tensor (torch.Tensor): tensor to be checked.
+
+    Returns:
+        True if last dimension is 2, else False.
+    """
+    return x.shape[-1] == 2
+
+
+def check_torchaudio_complex(tensor):
+    """Assert that tensor is Torchaudo-style complex-like (last dimension is 2).
+
+    Args:
+        tensor (torch.Tensor): tensor to be checked.
+
+    Raises:
+        AssertionError if last dimension is != 2.
+    """
+    if not is_torchaudio_complex(tensor):
+        raise AssertionError(
+            f"Tensor of shape {tensor.shape} is not Torchaudio-style complex-like"
+            "(expected last dimension to be == 2)"
+        )
 
 
 def to_torchaudio(tensor, dim=-2):

--- a/asteroid/masknn/_dccrn_architectures.py
+++ b/asteroid/masknn/_dccrn_architectures.py
@@ -1,0 +1,19 @@
+from ._dcunet_architectures import make_unet_encoder_decoder_args
+
+# fmt: off
+DCCRN_ARCHITECTURES = {
+    "DCCRN-CL": make_unet_encoder_decoder_args(
+        # Encoders:
+        # (in_chan, out_chan, kernel_size, stride, padding)
+        [
+            (  1,  32, (5, 2), (2, 1), (2, 0)),
+            ( 32,  64, (5, 2), (2, 1), (2, 1)),
+            ( 64, 128, (5, 2), (2, 1), (2, 0)),
+            (128, 256, (5, 2), (2, 1), (2, 1)),
+            (256, 256, (5, 2), (2, 1), (2, 0)),
+            (256, 256, (5, 2), (2, 1), (2, 1)),
+        ],
+        # Decoders: auto
+        "auto",
+    ),
+}

--- a/asteroid/masknn/_dcunet_architectures.py
+++ b/asteroid/masknn/_dcunet_architectures.py
@@ -1,0 +1,90 @@
+from ..utils.generic_utils import unet_decoder_args
+
+
+def make_unet_encoder_decoder_args(encoder_args, decoder_args):
+    encoder_args = [
+        (
+            in_chan,
+            out_chan,
+            kernel_size,
+            stride,
+            [n // 2 for n in kernel_size] if padding == "auto" else padding,
+        )
+        for in_chan, out_chan, kernel_size, stride, padding in encoder_args
+    ]
+
+    if decoder_args == "auto":
+        decoder_args = unet_decoder_args(encoder_args, skip_connections=True)
+
+    return encoder_args, decoder_args
+
+
+# fmt: off
+
+DCUNET_ARCHITECTURES = {
+    "DCUNet-10": make_unet_encoder_decoder_args(
+        # Encoders:
+        # (in_chan, out_chan, kernel_size, stride, padding)
+        [
+            ( 1, 32, (7, 5), (2, 2), "auto"),
+            (32, 64, (7, 5), (2, 2), "auto"),
+            (64, 64, (5, 3), (2, 2), "auto"),
+            (64, 64, (5, 3), (2, 2), "auto"),
+            (64, 64, (5, 3), (2, 1), "auto"),
+        ],
+        # Decoders: automatic inverse
+        "auto",
+    ),
+    "DCUNet-16": make_unet_encoder_decoder_args(
+        # Encoders:
+        # (in_chan, out_chan, kernel_size, stride, padding)
+        [
+            ( 1, 32, (7, 5), (2, 2), "auto"),
+            (32, 32, (7, 5), (2, 1), "auto"),
+            (32, 64, (7, 5), (2, 2), "auto"),
+            (64, 64, (5, 3), (2, 1), "auto"),
+            (64, 64, (5, 3), (2, 2), "auto"),
+            (64, 64, (5, 3), (2, 1), "auto"),
+            (64, 64, (5, 3), (2, 2), "auto"),
+            (64, 64, (5, 3), (2, 1), "auto"),
+        ],
+        # Decoders: automatic inverse
+        "auto",
+    ),
+    "DCUNet-20": make_unet_encoder_decoder_args(
+        # Encoders:
+        # (in_chan, out_chan, kernel_size, stride, padding)
+        [
+            ( 1, 32, (7, 1), (1, 1), "auto"),
+            (32, 32, (1, 7), (1, 1), "auto"),
+            (32, 64, (7, 5), (2, 2), "auto"),
+            (64, 64, (7, 5), (2, 1), "auto"),
+            (64, 64, (5, 3), (2, 2), "auto"),
+            (64, 64, (5, 3), (2, 1), "auto"),
+            (64, 64, (5, 3), (2, 2), "auto"),
+            (64, 64, (5, 3), (2, 1), "auto"),
+            (64, 64, (5, 3), (2, 2), "auto"),
+            (64, 90, (5, 3), (2, 1), "auto"),
+        ],
+        # Decoders: automatic inverse
+        "auto",
+    ),
+    "Large-DCUNet-20": make_unet_encoder_decoder_args(
+        # Encoders:
+        # (in_chan, out_chan, kernel_size, stride, padding)
+        [
+            ( 1,  45, (7, 1), (1, 1), "auto"),
+            (45,  45, (1, 7), (1, 1), "auto"),
+            (45,  90, (7, 5), (2, 2), "auto"),
+            (90,  90, (7, 5), (2, 1), "auto"),
+            (90,  90, (5, 3), (2, 2), "auto"),
+            (90,  90, (5, 3), (2, 1), "auto"),
+            (90,  90, (5, 3), (2, 2), "auto"),
+            (90,  90, (5, 3), (2, 1), "auto"),
+            (90,  90, (5, 3), (2, 2), "auto"),
+            (90, 128, (5, 3), (2, 1), "auto"),
+        ],
+        # Decoders: automatic inverse
+        "auto",
+    ),
+}

--- a/asteroid/masknn/activations.py
+++ b/asteroid/masknn/activations.py
@@ -1,5 +1,7 @@
+from functools import partial
 import torch
 from torch import nn
+from .. import complex_nn
 
 
 class Swish(nn.Module):
@@ -79,3 +81,12 @@ def get(identifier):
         return cls
     else:
         raise ValueError("Could not interpret activation identifier: " + str(identifier))
+
+
+def get_complex(identifier):
+    """Like `.get` but returns a complex activation created with `asteroid.complex_nn.OnReIm`."""
+    activation = get(identifier)
+    if activation is None:
+        return None
+    else:
+        return partial(complex_nn.OnReIm, activation)

--- a/asteroid/masknn/base.py
+++ b/asteroid/masknn/base.py
@@ -1,0 +1,120 @@
+import numpy as np
+import torch
+
+from .. import complex_nn
+
+
+class BaseUNet(torch.nn.Module):
+    """Base class for u-nets with skip connections between encoders and decoders.
+
+    (For u-nets without skip connections, simply use a `nn.Sequential`.)
+
+    Args:
+        encoders (List[torch.nn.Module]): List of encoders
+        decoders (List[torch.nn.Module]): List of decoders
+        intermediate_layer (Optional[torch.nn.Module], optional):
+            Layer between last encoder and first decoder.
+        output_layer (Optional[torch.nn.Module], optional):
+            Layer after last decoder.
+    """
+
+    def __init__(
+        self,
+        encoders,
+        decoders,
+        *,
+        intermediate_layer=None,
+        output_layer=None,
+    ):
+        super().__init__()
+
+        self.encoders = torch.nn.ModuleList(encoders)
+        self.decoders = torch.nn.ModuleList(decoders)
+        self.intermediate_layer = intermediate_layer or torch.nn.Identity()
+        self.output_layer = output_layer or torch.nn.Identity()
+
+    def forward(self, x):
+        enc_outs = []
+        for idx, enc in enumerate(self.encoders):
+            x = enc(x)
+            enc_outs.append(x)
+        x = self.intermediate_layer(x)
+        for idx, (enc_out, dec) in enumerate(zip(reversed(enc_outs[:-1]), self.decoders)):
+            x = dec(x)
+            x = torch.cat([x, enc_out], dim=1)
+        return self.output_layer(x)
+
+
+class BaseDCUMaskNet(BaseUNet):
+    """Base class for DCU-style mask nets. Used for DCUMaskNet and DCCRMaskNet.
+
+    The preferred way to instantiate this class is to use the ``default_architecture()``
+    classmethod.
+
+    Args:
+        encoders (list of length `N` of tuples of (in_chan, out_chan, kernel_size, stride, padding)):
+            Arguments of encoders of the u-net
+        decoders (list of length `N` of tuples of (in_chan, out_chan, kernel_size, stride, padding))
+            Arguments of decoders of the u-net
+        mask_bound (Optional[str], optional): Type of mask bound to use, as defined in [1].
+            Valid values are "tanh" ("BDT mask"), "sigmoid" ("BDSS mask"), None (unbounded mask).
+
+    Input shape is expected to be [batch, n_freqs, time], with `n_freqs - 1` divisible
+    by `f_0 * f_1 * ... * f_N` where `f_k` are the frequency strides of the encoders.
+
+    References:
+        [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
+        Hyeong-Seok Choi et al.
+        https://arxiv.org/abs/1903.03107
+    """
+
+    _architectures = NotImplemented
+
+    @classmethod
+    def default_architecture(cls, architecture: str, **kwargs):
+        """Create a masknet instance from a predefined, named architecture.
+
+        Args:
+            architecture (str): Name of predefined architecture. Valid values
+                are dependent on the concrete subclass of ``BaseDCUMaskNet``.
+            kwargs (optional): Passed to ``__init__`.
+        """
+        encoders, decoders = cls._architectures[architecture]
+        return cls(encoders, decoders, **kwargs)
+
+    def __init__(self, encoders, decoders, mask_bound="tanh", **kwargs):
+        self.encoder_args = encoders
+        self.decoder_args = decoders
+        self.mask_bound = mask_bound
+
+        # Avoid circual import
+        from .convolutional import DCUNetComplexDecoderBlock, DCUNetComplexEncoderBlock
+
+        super().__init__(
+            encoders=[DCUNetComplexEncoderBlock(*args) for args in encoders],
+            decoders=[DCUNetComplexDecoderBlock(*args) for args in decoders],
+            output_layer=torch.nn.Sequential(
+                complex_nn.ComplexConvTranspose2d(*decoders[-1]),
+                complex_nn.BoundComplexMask(mask_bound),
+            ),
+            **kwargs,
+        )
+
+    @property
+    def encoders_stride_product(self):
+        return np.prod([enc_stride for _, _, _, enc_stride, _ in self.encoder_args], axis=0)
+
+    @property
+    def decoders_stride_product(self):
+        return np.prod([enc_stride for _, _, _, enc_stride, _ in self.decoder_args], axis=0)
+
+    def forward(self, x):
+        # TODO: We can probably lift the shape requirements once Keras-style "same"
+        # padding for convolutions has landed: https://github.com/pytorch/pytorch/pull/42190
+        freq_prod, time_prod = self.encoders_stride_product
+        if (x.shape[1] - 1) % freq_prod or (x.shape[2] - 1) % time_prod:
+            raise TypeError(
+                f"Input shape must be [batch, freq + 1, time + 1] with freq divisible by "
+                f"{freq_prod} and time divisible by {time_prod}, got {x.shape} instead"
+            )
+        return super().forward(x.unsqueeze(1))

--- a/asteroid/masknn/norms.py
+++ b/asteroid/masknn/norms.py
@@ -1,6 +1,8 @@
+from functools import partial
 import torch
 from torch import nn
 from torch.nn.modules.batchnorm import _BatchNorm
+from .. import complex_nn
 
 EPS = 1e-8
 
@@ -153,3 +155,12 @@ def get(identifier):
         return cls
     else:
         raise ValueError("Could not interpret normalization identifier: " + str(identifier))
+
+
+def get_complex(identifier):
+    """Like `.get` but returns a complex norm created with `asteroid.complex_nn.OnComponents`."""
+    norm = get(identifier)
+    if norm is None:
+        return None
+    else:
+        return partial(complex_nn.OnComponents, norm)

--- a/asteroid/masknn/norms.py
+++ b/asteroid/masknn/norms.py
@@ -158,9 +158,9 @@ def get(identifier):
 
 
 def get_complex(identifier):
-    """Like `.get` but returns a complex norm created with `asteroid.complex_nn.OnComponents`."""
+    """Like `.get` but returns a complex norm created with `asteroid.complex_nn.OnReIm`."""
     norm = get(identifier)
     if norm is None:
         return None
     else:
-        return partial(complex_nn.OnComponents, norm)
+        return partial(complex_nn.OnReIm, norm)

--- a/asteroid/models/__init__.py
+++ b/asteroid/models/__init__.py
@@ -1,5 +1,7 @@
 # Models
 from .conv_tasnet import ConvTasNet
+from .dccrnet import DCCRNet
+from .dcunet import DCUNet
 from .dprnn_tasnet import DPRNNTasNet
 from .sudormrf import SuDORMRFImprovedNet, SuDORMRFNet
 from .dptnet import DPTNet
@@ -17,6 +19,8 @@ __all__ = [
     "DPTNet",
     "LSTMTasNet",
     "DeMask",
+    "DCUNet",
+    "DCCRNet",
     "save_publishable",
     "upload_publishable",
 ]

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -5,8 +5,8 @@ import numpy as np
 import torch
 from torch import nn
 
-from .. import torch_utils
 from ..masknn import activations
+from ..utils.torch_utils import pad_x_to_y
 from ..utils.hub_utils import cached_download
 
 
@@ -87,7 +87,7 @@ class BaseModel(nn.Module):
     def file_separate(
         self, filename: str, output_dir=None, force_overwrite=False, **kwargs
     ) -> None:
-        """Filename interface to `separate`."""
+        """ Filename interface to `separate`."""
         import soundfile as sf
 
         wav, fs = sf.read(filename, dtype="float32", always_2d=True)
@@ -254,7 +254,7 @@ class BaseEncoderMaskerDecoder(BaseModel):
         decoded = self.decoder(masked_tf_rep)
         decoded = self.postprocess_decoded(decoded)
 
-        reconstructed = torch_utils.pad_x_to_y(decoded, wav)
+        reconstructed = pad_x_to_y(decoded, wav)
         if was_one_d:
             return reconstructed.squeeze(0)
         else:

--- a/asteroid/models/dccrnet.py
+++ b/asteroid/models/dccrnet.py
@@ -1,0 +1,27 @@
+from ..masknn.recurrent import DCCRMaskNet
+from .dcunet import BaseDCUNet
+
+
+class DCCRNet(BaseDCUNet):
+    """DCCRNet as proposed in [1].
+
+    Args:
+        architecture (str): The architecture to use, must be "DCCRN-CL".
+        stft_kernel_size (int): STFT frame length to use
+        stft_stride (int, optional): STFT hop length to use.
+
+    References:
+        [1] : "DCCRN: Deep Complex Convolution Recurrent Network for Phase-Aware Speech Enhancement",
+        Yanxin Hu et al.
+        https://arxiv.org/abs/2008.00264
+    """
+
+    masknet_class = DCCRMaskNet
+
+    def __init__(self, *args, stft_kernel_size=512, masknet_kwargs=None, **kwargs):
+        super().__init__(
+            *args,
+            stft_kernel_size=stft_kernel_size,
+            masknet_kwargs={"n_freqs": stft_kernel_size // 2 + 1, **(masknet_kwargs or {})},
+            **kwargs,
+        )

--- a/asteroid/models/dcunet.py
+++ b/asteroid/models/dcunet.py
@@ -1,0 +1,64 @@
+import torch
+
+from .. import complex_nn
+from ..filterbanks import make_enc_dec
+from ..filterbanks.transforms import from_torchaudio
+from ..masknn.convolutional import DCUMaskNet
+from .base_models import BaseEncoderMaskerDecoder
+
+
+class BaseDCUNet(BaseEncoderMaskerDecoder):
+    """Base class for ``DCUNet`` and ``DCCRNet`` classes.
+
+    Args:
+        stft_kernel_size (int): STFT frame length to use
+        stft_stride (int, optional): STFT hop length to use.
+    """
+
+    masknet_class = DCUMaskNet
+
+    def __init__(self, architecture, stft_kernel_size=512, stft_stride=None, masknet_kwargs=None):
+        self.architecture = architecture
+        self.stft_kernel_size = stft_kernel_size
+        self.stft_stride = stft_stride
+        self.masknet_kwargs = masknet_kwargs
+
+        encoder, decoder = make_enc_dec(
+            "stft", kernel_size=stft_kernel_size, n_filters=stft_kernel_size, stride=stft_stride
+        )
+        masker = self.masknet_class.default_architecture(architecture, **(masknet_kwargs or {}))
+        super().__init__(encoder, masker, decoder)
+
+    def postprocess_encoded(self, tf_rep):
+        return complex_nn.as_torch_complex(tf_rep)
+
+    def postprocess_masked(self, masked_tf_rep):
+        return from_torchaudio(torch.view_as_real(masked_tf_rep))
+
+    def get_model_args(self):
+        """Arguments needed to re-instantiate the model."""
+        model_args = {
+            "architecture": self.architecture,
+            "stft_kernel_size": self.stft_kernel_size,
+            "stft_stride": self.stft_stride,
+            "masknet_kwargs": self.masknet_kwargs,
+        }
+        return model_args
+
+
+class DCUNet(BaseDCUNet):
+    """DCUNet as proposed in [1].
+
+    Args:
+        architecture (str): The architecture to use, any of
+            "DCUNet-10", "DCUNet-16", "DCUNet-20", "Large-DCUNet-20".
+        stft_kernel_size (int): STFT frame length to use
+        stft_stride (int, optional): STFT hop length to use.
+
+    References:
+        [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
+        Hyeong-Seok Choi et al.
+        https://arxiv.org/abs/1903.03107
+    """
+
+    masknet_class = DCUMaskNet

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -1,9 +1,9 @@
 from torch import nn
 from .base_models import BaseModel
 from ..filterbanks import make_enc_dec
-from ..masknn import norms, activations
 from ..filterbanks.transforms import take_mag, take_cat
-from .. import torch_utils
+from ..masknn import norms, activations
+from ..utils.torch_utils import pad_x_to_y
 
 
 class DeMask(BaseModel):
@@ -142,7 +142,7 @@ class DeMask(BaseModel):
         else:
             raise NotImplementedError
 
-        out_wavs = torch_utils.pad_x_to_y(self.decoder(masked_tf_rep), wav)
+        out_wavs = pad_x_to_y(self.decoder(masked_tf_rep), wav)
         if was_one_d:
             return out_wavs.squeeze(0)
         return out_wavs

--- a/asteroid/utils/__init__.py
+++ b/asteroid/utils/__init__.py
@@ -1,3 +1,10 @@
+from .generic_utils import (
+    average_arrays_in_dic,
+    flatten_dict,
+    get_wav_random_start_stop,
+    has_arg,
+    unet_decoder_args,
+)
 from .parser_utils import (
     prepare_parser_from_dict,
     parse_args_as_dict,
@@ -8,7 +15,6 @@ from .parser_utils import (
     isint,
 )
 from .torch_utils import tensors_to_device, to_cuda
-from .generic_utils import has_arg, flatten_dict, average_arrays_in_dic, get_wav_random_start_stop
 
 # The functions above were all in asteroid/utils.py before refactoring into
 # asteroid/utils/*_utils.py files. They are imported for backward compatibility.
@@ -27,4 +33,5 @@ __all__ = [
     "flatten_dict",
     "average_arrays_in_dic",
     "get_wav_random_start_stop",
+    "unet_decoder_args",
 ]

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -5,9 +5,19 @@ import numpy as np
 import soundfile as sf
 import asteroid
 from asteroid import models
+from asteroid.filterbanks import make_enc_dec
+from asteroid.models import (
+    ConvTasNet,
+    DCCRNet,
+    DCUNet,
+    DeMask,
+    DPRNNTasNet,
+    DPTNet,
+    LSTMTasNet,
+    SuDORMRFImprovedNet,
+    SuDORMRFNet,
+)
 from asteroid.models.base_models import BaseModel
-from asteroid.models import ConvTasNet, DPRNNTasNet, DPTNet, LSTMTasNet, DeMask
-from asteroid.models import SuDORMRFNet, SuDORMRFImprovedNet
 
 
 def test_convtasnet_sep():
@@ -106,6 +116,15 @@ def test_sudormrf_imp():
 
 def test_dptnet():
     _default_test_model(DPTNet(2, ff_hid=10, chunk_size=4, n_repeats=2))
+
+
+def test_dcunet():
+    _, istft = make_enc_dec("stft", 512, 512)
+    _default_test_model(DCUNet("DCUNet-10"), input_samples=istft(torch.zeros((514, 17))).shape[0])
+
+
+def test_dccrnet():
+    _default_test_model(DCCRNet("DCCRN-CL"), input_samples=1300)
 
 
 def _default_test_model(model, input_samples=801):

--- a/tests/utils/utils_test.py
+++ b/tests/utils/utils_test.py
@@ -101,3 +101,22 @@ def test_get_start_stop(sig_len, desired):
     # Stop must be chosen so that `start + stop == desired`
     # (or if `desired < sig_len`, then exactly `sig_len`).
     assert stop == start + min(sig_len, desired)
+
+
+def test_unet_decoder_args():
+    a, b, c, d = np.random.randint(1, 100, size=4)
+    encoders = [
+        (a, b, "ks1", "st1", "pad1"),
+        (b, c, "ks2", "st2", "pad2"),
+        (c, d, "ks3", "st3", "pad3"),
+    ]
+    assert utils.unet_decoder_args(encoders, skip_connections=False) == [
+        (1 * d, c, "ks3", "st3", "pad3"),
+        (1 * c, b, "ks2", "st2", "pad2"),
+        (1 * b, a, "ks1", "st1", "pad1"),
+    ]
+    assert utils.unet_decoder_args(encoders, skip_connections=True) == [
+        (1 * d, c, "ks3", "st3", "pad3"),
+        (2 * c, b, "ks2", "st2", "pad2"),
+        (2 * b, a, "ks1", "st1", "pad1"),
+    ]


### PR DESCRIPTION
This is a WIP implementation of [Phase-aware Single-stage Speech Denoising and Dereverberation with U-Net](https://arxiv.org/abs/2006.00687).

I also want to implement [DCCRN: Deep Complex Convolution Recurrent Network for Phase-Aware Speech Enhancement](https://arxiv.org/abs/2008.00264) soon.

I'd like to get feedback on

- Usage of PyTorch 1.7+ native complex128 dtype rather than Asteroid style complex type or torchaudio style complex type.
- Code structure, class names, code placing. Many things I wasn't sure where to place in the Asteroid codebase.
- Location of complex norms, activations, etc.
- Dealing with input shapes in `DCUMaskNet.forward`. Due to the encoder/decoder structure only specific T/F dimensions will work without padding or other workarounds.