### PR TITLE
[cli] Add asteroid-infer CLI to enhance/separate from the command line

### DIFF
--- a/asteroid/scripts/asteroid_cli.py
+++ b/asteroid/scripts/asteroid_cli.py
@@ -90,6 +90,13 @@ def upload():
 
 
 def infer():
+    """ CLI function to run pretrained model inference on wav files.
+
+    Args:
+        url_or_path(str): Path to the pretrained model.
+        files (List(str)): Path to the wav files to separate. Also support list
+            of filenames, directory names and globs.
+    """
     import argparse
 
     parser = argparse.ArgumentParser()
@@ -98,7 +105,8 @@ def infer():
         "--files",
         default=None,
         type=str,
-        help="Path to the wav files to separate. Also support list of filenames, directory names and globs.",
+        help="Path to the wav files to separate. Also support list of filenames, "
+        "directory names and globs.",
         nargs="+",
     )
     args = parser.parse_args()

--- a/asteroid/scripts/asteroid_cli.py
+++ b/asteroid/scripts/asteroid_cli.py
@@ -1,8 +1,20 @@
 import os
 import yaml
+import itertools
+import glob
+import warnings
+from typing import List
 
 import asteroid
 from asteroid.models.publisher import upload_publishable
+from asteroid.models.base_models import BaseModel
+
+
+SUPPORTED_EXTENSIONS = [
+    ".wav",
+    ".flac",
+    ".ogg",
+]
 
 
 def upload():
@@ -75,3 +87,49 @@ def upload():
             "Thanks a lot for sharing your model! Don't forget to create"
             "a model card in the repo! "
         )
+
+
+def infer():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("url_or_path", type=str, help="Path to the pretrained model.")
+    parser.add_argument(
+        "--files",
+        default=None,
+        type=str,
+        help="Path to the wav files to separate. Also support list of filenames, directory names and globs.",
+        nargs="+",
+    )
+    args = parser.parse_args()
+
+    model = BaseModel.from_pretrained(pretrained_model_conf_or_path=args.url_or_path)
+    file_list = _process_files_as_list(args.files)
+
+    for f in file_list:
+        model.separate(f)
+
+
+def _process_files_as_list(files_str: List) -> List:
+    """ Support filename, folder name, and globs. Returns list of filenames."""
+    all_files = []
+    for f in files_str:
+        # Existing file
+        if os.path.isfile(f):
+            all_files.append(f)
+        # Glob folder and append.
+        elif os.path.isdir(f):
+            all_files.extend(glob_dir(f))
+        else:
+            local_list = glob.glob(f)
+            if not local_list:
+                warnings.warn(f"Could find any file that matched {f}", UserWarning)
+            all_files.extend(local_list)
+    return all_files
+
+
+def glob_dir(d):
+    """ Return all filenames in directory that match the supported extensions."""
+    return list(
+        itertools.chain(*[glob.glob(os.path.join(d, "**/*" + ext)) for ext in SUPPORTED_EXTENSIONS])
+    )

--- a/asteroid/scripts/asteroid_cli.py
+++ b/asteroid/scripts/asteroid_cli.py
@@ -131,5 +131,10 @@ def _process_files_as_list(files_str: List) -> List:
 def glob_dir(d):
     """ Return all filenames in directory that match the supported extensions."""
     return list(
-        itertools.chain(*[glob.glob(os.path.join(d, "**/*" + ext)) for ext in SUPPORTED_EXTENSIONS])
+        itertools.chain(
+            *[
+                glob.glob(os.path.join(d, "**/*" + ext), recursive=True)
+                for ext in SUPPORTED_EXTENSIONS
+            ]
+        )
     )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,12 @@ setup(
         "torch_stoi",
     ],
     extras_require={"visualize": ["seaborn"], "tests": ["pytest"],},
-    entry_points={"console_scripts": ["asteroid-upload=asteroid.scripts.asteroid_cli:upload"],},
+    entry_points={
+        "console_scripts": [
+            "asteroid-upload=asteroid.scripts.asteroid_cli:upload",
+            "asteroid-infer=asteroid.scripts.asteroid_cli:infer",
+        ],
+    },
     packages=find_packages(),
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
The is a first iteration, it works, but it's not optimal and raises some flaws of the current code. 

### Usage 

```bash
asteroid-infer url_or_path --files filename
asteroid-cli 'mpariente/ConvTasNet_WHAM!_sepclean' --files tmp.wav
asteroid-cli 'mpariente/ConvTasNet_WHAM!_sepclean'  --files a_folder a_filename a_glob/**/*.wav
```
`files` can be a list of filenames, foldernames and globs, we'll handle it. In case of a folder, we check the supported file formats in the folder (recursively)

### Cool things
- Thanks to `BaseModel`, we can now load all the models, just given the model pack, which makes it very easy. 
- Based on  `separate`, not much new code here.
- The `--files` argument is cool because versatile.

### Bad things
- soundfile doesn't support all format. Should we have a backup strategy? Librosa supports more formats? 
- Bash breaks on `!` unless we use single quotes on them, avoid `!` in the future.
- We currently have no idea the sample rate the model supports and this can break everything, we should add it in the saved models
- We also don't know the number of sources, so we cannot use the current version of `LambdaOverlapAdd`, could we remove the `n_src` argument in `LambdaOverlapAdd` so that we could use it in the CLI? It can be infered at runtime IMO (and if the (batch, n_src, time) format is not respected, errors will be raised. 

@jonashaag and @popcornell please? 


### Note
You need to reinstall Asteroid with `python setup.py develop` to have the new CLI modes I think.