### PR TITLE
[src & tests] Add Hungarian matcher to solve the linear sum assignement in PITLossWrapper

### DIFF
--- a/asteroid/dsp/overlap_add.py
+++ b/asteroid/dsp/overlap_add.py
@@ -1,6 +1,6 @@
 import torch
 from scipy.signal import get_window
-from asteroid.losses import PITLossWrapper
+from asteroid.losses.pit_wrapper import PITReorder
 from torch import nn
 
 
@@ -176,8 +176,8 @@ def _reorder_sources(
         return -torch.sum(x.unsqueeze(1) * y.unsqueeze(2), dim=-1)
 
     # We maximize correlation-like between previous and current.
-    pit = PITLossWrapper(reorder_func)
-    current = pit(current, previous, return_est=True)[1]
+    pit = PITReorder(reorder_func)
+    current = pit(current, previous)
     return current.reshape(batch, frames)
 
 

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -226,7 +226,7 @@ class PITLossWrapper(nn.Module):
 
     @staticmethod
     def reorder_source(source, batch_indices):
-        """ Reorder sources according to the best permutation.
+        """Reorder sources according to the best permutation.
 
         Args:
             source (torch.Tensor): Tensor of shape [batch, n_src, time]

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -317,3 +317,18 @@ class PITLossWrapper(nn.Module):
         batch_indices = torch.tensor([linear_sum_assignment(pwl)[1] for pwl in pwl_copy])
         min_loss = torch.gather(pwl, 2, batch_indices[..., None]).mean([-1, -2])
         return min_loss, batch_indices
+
+
+class PITReorder(PITLossWrapper):
+    """Permutation invariant reorderer. Only returns the reordered estimates.
+    See `:py:class:asteroid.losses.PITLossWrapper`."""
+
+    def forward(self, est_targets, targets, reduce_kwargs=None, **kwargs):
+        _, reordered = super().forward(
+            est_targets=est_targets,
+            targets=targets,
+            return_est=True,
+            reduce_kwargs=reduce_kwargs,
+            **kwargs,
+        )
+        return reordered

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -102,7 +102,7 @@ class PITLossWrapper(nn.Module):
         elif self.pit_from == "perm_avg":
             # Cannot get pairwise losses from this type of loss.
             # Find best permutation directly.
-            min_loss, min_loss_idx = self.best_perm_from_perm_avg_loss(
+            min_loss, batch_indices = self.best_perm_from_perm_avg_loss(
                 self.loss_func, est_targets, targets, **kwargs
             )
             # Take the mean over the batch
@@ -250,7 +250,6 @@ class PITLossWrapper(nn.Module):
         Args:
             pair_wise_losses (:class:`torch.Tensor`):
                 Tensor of shape [batch, n_src, n_src]. Pairwise losses.
-            n_src (int): Number of sources.
             perm_reduce (Callable): torch function to reduce permutation losses.
                 Defaults to None (equivalent to mean). Signature of the func
                 (pwl_set, **kwargs) : (B, n_src!, n_src) --> (B, n_src!)

--- a/tests/losses/pit_wrapper_test.py
+++ b/tests/losses/pit_wrapper_test.py
@@ -114,3 +114,19 @@ def test_permreduce_args():
     loss_func = PITLossWrapper(pairwise_mse, pit_from="pw_mtx", perm_reduce=reduce_func)
     weights = torch.softmax(torch.randn(10, n_src), dim=-1)
     loss_func(est_sources, sources, reduce_kwargs={"class_weights": weights})
+
+
+def best_perm():
+    sources = torch.randn(6, 10, 1000)
+    pwl = torch.randn(6, 10, 10)
+
+    min_loss, min_idx = PITLossWrapper.find_best_perm(pwl, 10)
+    min_loss_hun = PITLossWrapper.find_best_perm_hungarian(pwl, 10)
+
+    PITLossWrapper.reorder_source(sources, 10, min_idx)
+
+    # assert_allclose(min_loss, min_loss_hun)
+
+
+if __name__ == "__main__":
+    best_perm()

--- a/tests/losses/pit_wrapper_test.py
+++ b/tests/losses/pit_wrapper_test.py
@@ -116,17 +116,17 @@ def test_permreduce_args():
     loss_func(est_sources, sources, reduce_kwargs={"class_weights": weights})
 
 
-def best_perm():
-    sources = torch.randn(6, 10, 1000)
-    pwl = torch.randn(6, 10, 10)
+@pytest.mark.parametrize("n_src", [2, 4, 5, 6, 8])
+def test_best_perm_match(n_src):
+    pwl = torch.randn(2, n_src, n_src)
 
-    min_loss, min_idx = PITLossWrapper.find_best_perm(pwl, 10)
-    min_loss_hun = PITLossWrapper.find_best_perm_hungarian(pwl, 10)
+    min_loss, min_idx = PITLossWrapper.find_best_perm_factorial(pwl)
+    min_loss_hun, min_idx_hun = PITLossWrapper.find_best_perm_hungarian(pwl)
 
-    PITLossWrapper.reorder_source(sources, 10, min_idx)
+    assert_allclose(min_loss, min_loss_hun)
+    assert_allclose(min_idx, min_idx_hun)
 
-    # assert_allclose(min_loss, min_loss_hun)
 
-
-if __name__ == "__main__":
-    best_perm()
+def test_raises_wrong_pit_from():
+    with pytest.raises(ValueError):
+        PITLossWrapper(lambda x: x, pit_from="unknown_mode")


### PR DESCRIPTION
This is WIP, but I think we could merge it pretty fast. 

@popcornell, if we were to change the `PITLossWrapper`, what would you like in the output? Currently the `min_loss_idx` in `find_best_perm` is really not useful because you need to rebuild the permutations to get the indices. 

We might have a backward-breaking release with the Filterbank `filters` from #237, maybe we could change that as well because I know it was blocking you in the past. 
I'll comment in the code and I'd like your feedback