### PR TITLE
[src] Restore linear activation as default in ConvTasNet and DPRNN

### DIFF
--- a/asteroid/models/conv_tasnet.py
+++ b/asteroid/models/conv_tasnet.py
@@ -59,7 +59,7 @@ class ConvTasNet(BaseTasNet):
         kernel_size=16,
         n_filters=512,
         stride=8,
-        encoder_activation="relu",
+        encoder_activation=None,
         **fb_kwargs,
     ):
         encoder, decoder = make_enc_dec(

--- a/asteroid/models/dprnn_tasnet.py
+++ b/asteroid/models/dprnn_tasnet.py
@@ -68,7 +68,7 @@ class DPRNNTasNet(BaseTasNet):
         kernel_size=16,
         n_filters=64,
         stride=8,
-        encoder_activation="relu",
+        encoder_activation=None,
         **fb_kwargs,
     ):
         encoder, decoder = make_enc_dec(


### PR DESCRIPTION
Bug introduced in #204 
Should solve #255 

The default activation function at the output of the encoder should be linear for ConvTasNet and DPRNN, as it was in the past. 
Models trained with other encoder activation since v0.3.2 will still load correctly because the `encoder_activation` key is in the models args from there. 