### PR TITLE
[hub] Add software version section in published models

### DIFF
--- a/asteroid/models/publisher.py
+++ b/asteroid/models/publisher.py
@@ -291,6 +291,11 @@ def make_metadata_from_model(model):
     display_result = {k: v for k, v in infos["final_metrics"].items() if "pesq" not in k.lower()}
     description += display_one_level_dict(display_result)
 
+    # Software section
+    description += "<p>&nbsp;</p>"
+    description += "<p><strong>Versions:</strong></p>"
+    description += display_one_level_dict(infos["software_versions"])
+
     # License section
     description += "<p>&nbsp;</p>"
     description += "<p><strong>License notice:</strong></p>"


### PR DESCRIPTION
It's a useful info to have. 
Next thing will be to plot the train/val loss in the zenodo card. 
