### PR TITLE
[src&tests] Improve scheduler's docs + add plot method

### DIFF
--- a/asteroid/engine/schedulers.py
+++ b/asteroid/engine/schedulers.py
@@ -1,3 +1,4 @@
+import torch
 from torch.optim.optimizer import Optimizer
 
 
@@ -33,6 +34,23 @@ class _BaseScheduler(object):
 
     def state_dict(self):
         return {key: value for key, value in self.__dict__.items()}
+
+    def plot(self, start=0, stop=100_000):  # noqa
+        """Plot the scheduler values from start to stop."""
+        import matplotlib.pyplot as plt
+
+        all_lr = self.as_tensor(start=start, stop=stop)
+        plt.plot(all_lr.numpy())
+        plt.show()
+
+    def as_tensor(self, start=0, stop=100_000):
+        """Returns the scheduler values from start to stop."""
+        lr_list = []
+        for _ in range(start, stop):
+            self.step_num += 1
+            lr_list.append(self._get_lr())
+        self.step_num = 0
+        return torch.tensor(lr_list)
 
 
 class NoamScheduler(_BaseScheduler):
@@ -128,3 +146,12 @@ class DPTNetScheduler(_BaseScheduler):
                 * min(self.step_num ** (-0.5), self.step_num * self.warmup_steps ** (-1.5))
             )
         return lr
+
+    def as_tensor(self, start=0, stop=None):
+        stop = stop or self.warmup_steps * 2
+        lr_list = []
+        for _ in range(start, stop):
+            self.step_num += 1
+            lr_list.append(self._get_lr())
+        self.step_num = 0
+        return torch.tensor(lr_list)

--- a/asteroid/engine/schedulers.py
+++ b/asteroid/engine/schedulers.py
@@ -146,12 +146,3 @@ class DPTNetScheduler(_BaseScheduler):
                 * min(self.step_num ** (-0.5), self.step_num * self.warmup_steps ** (-1.5))
             )
         return lr
-
-    def as_tensor(self, start=0, stop=None):
-        stop = stop or self.warmup_steps * 2
-        lr_list = []
-        for _ in range(start, stop):
-            self.step_num += 1
-            lr_list.append(self._get_lr())
-        self.step_num = 0
-        return torch.tensor(lr_list)

--- a/asteroid/engine/system.py
+++ b/asteroid/engine/system.py
@@ -20,7 +20,9 @@ class System(pl.LightningModule):
         train_loader (torch.utils.data.DataLoader): Training dataloader.
         val_loader (torch.utils.data.DataLoader): Validation dataloader.
         scheduler (torch.optim.lr_scheduler._LRScheduler): Instance, or list
-            of learning rate schedulers.
+            of learning rate schedulers. Also supports dict or list of dict as
+            `{"interval": "batch", "scheduler": sched}` where `interval=="batch"`
+            for batch-wise schedulers and `interval=="epoch"` for classical ones.
         config: Anything to be saved with the checkpoints during training.
             The config dictionary to re-instantiate the run for example.
     .. note:: By default, `training_step` (used by `pytorch-lightning` in the
@@ -160,7 +162,7 @@ class System(pl.LightningModule):
         return {"val_loss": avg_loss, "log": tensorboard_logs, "progress_bar": tensorboard_logs}
 
     def configure_optimizers(self):
-        """ Required by pytorch-lightning. """
+        """Initialize optimizers, batch-wise and epoch-wise schedulers."""
 
         if self.scheduler is not None:
             if not isinstance(self.scheduler, (list, tuple)):

--- a/tests/engine/scheduler_test.py
+++ b/tests/engine/scheduler_test.py
@@ -45,6 +45,8 @@ def test_noam_scheduler():
         scheduler=scheduler,
     )
     trainer.fit(system)
+    # Test `as_tensor` for `plot`
+    scheduler["scheduler"].as_tensor()
 
 
 def test_dptnet_scheduler():
@@ -64,3 +66,5 @@ def test_dptnet_scheduler():
         scheduler=scheduler,
     )
     trainer.fit(system)
+    # Test `as_tensor` for `plot`
+    scheduler["scheduler"].as_tensor()


### PR DESCRIPTION
- `plot` can be useful for the lazy ones (me included)
- It was a bit undiscoverable till now. It's still pretty undiscoverable but at least we mention it in the docs. 