### PR TITLE
[src&tests] Add sample_rate in `BaseEncoderMaskerDecoder` 

### DIFF
--- a/asteroid/filterbanks/__init__.py
+++ b/asteroid/filterbanks/__init__.py
@@ -12,6 +12,7 @@ def make_enc_dec(
     n_filters,
     kernel_size,
     stride=None,
+    sample_rate=8000,
     who_is_pinv=None,
     padding=0,
     output_padding=0,
@@ -28,6 +29,8 @@ def make_enc_dec(
         kernel_size (int): Length of the filters.
         stride (int, optional): Stride of the convolution.
             If None (default), set to ``kernel_size // 2``.
+        sample_rate (int): Sample rate of the expected audio.
+            Defaults to 8000.
         who_is_pinv (str, optional): If `None`, no pseudo-inverse filters will
             be used. If string (among [``'encoder'``, ``'decoder'``]), decides
             which of ``Encoder`` or ``Decoder`` will be the pseudo inverse of
@@ -45,20 +48,20 @@ def make_enc_dec(
     fb_class = get(fb_name)
 
     if who_is_pinv in ["dec", "decoder"]:
-        fb = fb_class(n_filters, kernel_size, stride=stride, **kwargs)
+        fb = fb_class(n_filters, kernel_size, stride=stride, sample_rate=sample_rate, **kwargs)
         enc = Encoder(fb, padding=padding)
         # Decoder filterbank is pseudo inverse of encoder filterbank.
         dec = Decoder.pinv_of(fb)
     elif who_is_pinv in ["enc", "encoder"]:
-        fb = fb_class(n_filters, kernel_size, stride=stride, **kwargs)
+        fb = fb_class(n_filters, kernel_size, stride=stride, sample_rate=sample_rate, **kwargs)
         dec = Decoder(fb, padding=padding, output_padding=output_padding)
         # Encoder filterbank is pseudo inverse of decoder filterbank.
         enc = Encoder.pinv_of(fb)
     else:
-        fb = fb_class(n_filters, kernel_size, stride=stride, **kwargs)
+        fb = fb_class(n_filters, kernel_size, stride=stride, sample_rate=sample_rate, **kwargs)
         enc = Encoder(fb, padding=padding)
         # Filters between encoder and decoder should not be shared.
-        fb = fb_class(n_filters, kernel_size, stride=stride, **kwargs)
+        fb = fb_class(n_filters, kernel_size, stride=stride, sample_rate=sample_rate, **kwargs)
         dec = Decoder(fb, padding=padding, output_padding=output_padding)
     return enc, dec
 

--- a/asteroid/filterbanks/analytic_free_fb.py
+++ b/asteroid/filterbanks/analytic_free_fb.py
@@ -15,7 +15,7 @@ class AnalyticFreeFB(Filterbank):
         kernel_size (int): Length of the filters.
         stride (int, optional): Stride of the convolution.
             If None (default), set to ``kernel_size // 2``.
-        sample_rate (int): Sample rate of the expected audio.
+        sample_rate (float): Sample rate of the expected audio.
             Defaults to 8000.
 
     Attributes:
@@ -27,7 +27,7 @@ class AnalyticFreeFB(Filterbank):
         Antoine Deleforge, Emmanuel Vincent.
     """
 
-    def __init__(self, n_filters, kernel_size, stride=None, sample_rate=8000, **kwargs):
+    def __init__(self, n_filters, kernel_size, stride=None, sample_rate=8000.0, **kwargs):
         super().__init__(n_filters, kernel_size, stride=stride, sample_rate=sample_rate)
         self.cutoff = int(n_filters // 2)
         self.n_feats_out = 2 * self.cutoff

--- a/asteroid/filterbanks/analytic_free_fb.py
+++ b/asteroid/filterbanks/analytic_free_fb.py
@@ -15,6 +15,8 @@ class AnalyticFreeFB(Filterbank):
         kernel_size (int): Length of the filters.
         stride (int, optional): Stride of the convolution.
             If None (default), set to ``kernel_size // 2``.
+        sample_rate (int): Sample rate of the expected audio.
+            Defaults to 8000.
 
     Attributes:
         n_feats_out (int): Number of output filters.
@@ -25,8 +27,8 @@ class AnalyticFreeFB(Filterbank):
         Antoine Deleforge, Emmanuel Vincent.
     """
 
-    def __init__(self, n_filters, kernel_size, stride=None, **kwargs):
-        super(AnalyticFreeFB, self).__init__(n_filters, kernel_size, stride=stride)
+    def __init__(self, n_filters, kernel_size, stride=None, sample_rate=8000, **kwargs):
+        super().__init__(n_filters, kernel_size, stride=stride, sample_rate=sample_rate)
         self.cutoff = int(n_filters // 2)
         self.n_feats_out = 2 * self.cutoff
         if n_filters % 2 != 0:

--- a/asteroid/filterbanks/enc_dec.py
+++ b/asteroid/filterbanks/enc_dec.py
@@ -42,6 +42,7 @@ class Filterbank(nn.Module):
             "n_filters": self.n_filters,
             "kernel_size": self.kernel_size,
             "stride": self.stride,
+            "sample_rate": self.sample_rate,
         }
         return config
 

--- a/asteroid/filterbanks/enc_dec.py
+++ b/asteroid/filterbanks/enc_dec.py
@@ -13,12 +13,14 @@ class Filterbank(nn.Module):
         kernel_size (int): Length of the filters.
         stride (int, optional): Stride of the conv or transposed conv. (Hop size).
             If None (default), set to ``kernel_size // 2``.
+        sample_rate (int): Sample rate of the expected audio.
+            Defaults to 8000.
 
     Attributes:
         n_feats_out (int): Number of output filters.
     """
 
-    def __init__(self, n_filters, kernel_size, stride=None):
+    def __init__(self, n_filters, kernel_size, stride=None, sample_rate=8000):
         super(Filterbank, self).__init__()
         self.n_filters = n_filters
         self.kernel_size = kernel_size
@@ -26,6 +28,7 @@ class Filterbank(nn.Module):
         # If not specified otherwise in the filterbank's init, output
         # number of features is equal to number of required filters.
         self.n_feats_out = n_filters
+        self.sample_rate = sample_rate
 
     @property
     def filters(self):

--- a/asteroid/filterbanks/enc_dec.py
+++ b/asteroid/filterbanks/enc_dec.py
@@ -66,6 +66,7 @@ class _EncDec(nn.Module):
     def __init__(self, filterbank, is_pinv=False):
         super(_EncDec, self).__init__()
         self.filterbank = filterbank
+        self.sample_rate = getattr(filterbank, "sample_rate", None)
         self.stride = self.filterbank.stride
         self.is_pinv = is_pinv
 

--- a/asteroid/filterbanks/enc_dec.py
+++ b/asteroid/filterbanks/enc_dec.py
@@ -13,14 +13,14 @@ class Filterbank(nn.Module):
         kernel_size (int): Length of the filters.
         stride (int, optional): Stride of the conv or transposed conv. (Hop size).
             If None (default), set to ``kernel_size // 2``.
-        sample_rate (int): Sample rate of the expected audio.
+        sample_rate (float): Sample rate of the expected audio.
             Defaults to 8000.
 
     Attributes:
         n_feats_out (int): Number of output filters.
     """
 
-    def __init__(self, n_filters, kernel_size, stride=None, sample_rate=8000):
+    def __init__(self, n_filters, kernel_size, stride=None, sample_rate=8000.0):
         super(Filterbank, self).__init__()
         self.n_filters = n_filters
         self.kernel_size = kernel_size

--- a/asteroid/filterbanks/free_fb.py
+++ b/asteroid/filterbanks/free_fb.py
@@ -12,7 +12,7 @@ class FreeFB(Filterbank):
         kernel_size (int): Length of the filters.
         stride (int, optional): Stride of the convolution.
             If None (default), set to ``kernel_size // 2``.
-        sample_rate (int): Sample rate of the expected audio.
+        sample_rate (float): Sample rate of the expected audio.
             Defaults to 8000.
 
     Attributes:
@@ -24,7 +24,7 @@ class FreeFB(Filterbank):
         Antoine Deleforge, Emmanuel Vincent.
     """
 
-    def __init__(self, n_filters, kernel_size, stride=None, sample_rate=8000, **kwargs):
+    def __init__(self, n_filters, kernel_size, stride=None, sample_rate=8000.0, **kwargs):
         super().__init__(n_filters, kernel_size, stride=stride, sample_rate=sample_rate)
         self._filters = nn.Parameter(torch.ones(n_filters, 1, kernel_size))
         for p in self.parameters():

--- a/asteroid/filterbanks/free_fb.py
+++ b/asteroid/filterbanks/free_fb.py
@@ -12,6 +12,8 @@ class FreeFB(Filterbank):
         kernel_size (int): Length of the filters.
         stride (int, optional): Stride of the convolution.
             If None (default), set to ``kernel_size // 2``.
+        sample_rate (int): Sample rate of the expected audio.
+            Defaults to 8000.
 
     Attributes:
         n_feats_out (int): Number of output filters.
@@ -22,8 +24,8 @@ class FreeFB(Filterbank):
         Antoine Deleforge, Emmanuel Vincent.
     """
 
-    def __init__(self, n_filters, kernel_size, stride=None, **kwargs):
-        super(FreeFB, self).__init__(n_filters, kernel_size, stride=stride)
+    def __init__(self, n_filters, kernel_size, stride=None, sample_rate=8000, **kwargs):
+        super().__init__(n_filters, kernel_size, stride=stride, sample_rate=sample_rate)
         self._filters = nn.Parameter(torch.ones(n_filters, 1, kernel_size))
         for p in self.parameters():
             nn.init.xavier_normal_(p)

--- a/asteroid/filterbanks/multiphase_gammatone_fb.py
+++ b/asteroid/filterbanks/multiphase_gammatone_fb.py
@@ -22,8 +22,7 @@ class MultiphaseGammatoneFB(Filterbank):
     """
 
     def __init__(self, n_filters=128, kernel_size=16, sample_rate=8000, stride=None, **kwargs):
-        super().__init__(n_filters, kernel_size, stride=stride)
-        self.sample_rate = sample_rate
+        super().__init__(n_filters, kernel_size, stride=stride, sample_rate=sample_rate)
         self.n_feats_out = n_filters
         length_in_seconds = kernel_size / sample_rate
         mpgtf = generate_mpgtf(sample_rate, length_in_seconds, n_filters)

--- a/asteroid/filterbanks/multiphase_gammatone_fb.py
+++ b/asteroid/filterbanks/multiphase_gammatone_fb.py
@@ -11,7 +11,7 @@ class MultiphaseGammatoneFB(Filterbank):
     Args:
         n_filters (int): Number of filters.
         kernel_size (int): Length of the filters.
-        sample_rate (int, optional): The sample rate (used for initialization).
+        sample_rate (float, optional): The sample rate (used for initialization).
         stride (int, optional): Stride of the convolution. If None (default),
             set to ``kernel_size // 2``.
 
@@ -21,7 +21,7 @@ class MultiphaseGammatoneFB(Filterbank):
         Available: `<https://ieeexplore.ieee.org/document/9053602/>`
     """
 
-    def __init__(self, n_filters=128, kernel_size=16, sample_rate=8000, stride=None, **kwargs):
+    def __init__(self, n_filters=128, kernel_size=16, sample_rate=8000.0, stride=None, **kwargs):
         super().__init__(n_filters, kernel_size, stride=stride, sample_rate=sample_rate)
         self.n_feats_out = n_filters
         length_in_seconds = kernel_size / sample_rate

--- a/asteroid/filterbanks/param_sinc_fb.py
+++ b/asteroid/filterbanks/param_sinc_fb.py
@@ -40,8 +40,7 @@ class ParamSincFB(Filterbank):
                 + "kernel_size={} so filters are odd".format(kernel_size + 1)
             )
             kernel_size += 1
-        super(ParamSincFB, self).__init__(n_filters, kernel_size, stride=stride)
-        self.sample_rate = sample_rate
+        super().__init__(n_filters, kernel_size, stride=stride, sample_rate=sample_rate)
         self.min_low_hz, self.min_band_hz = min_low_hz, min_band_hz
 
         self.half_kernel = self.kernel_size // 2

--- a/asteroid/filterbanks/param_sinc_fb.py
+++ b/asteroid/filterbanks/param_sinc_fb.py
@@ -15,7 +15,7 @@ class ParamSincFB(Filterbank):
         kernel_size (int): Length of the filters.
         stride (int, optional): Stride of the convolution. If None (default),
             set to ``kernel_size // 2``.
-        sample_rate (int, optional): The sample rate (used for initialization).
+        sample_rate (float, optional): The sample rate (used for initialization).
         min_low_hz (int, optional): Lowest low frequency allowed (Hz).
         min_band_hz (int, optional): Lowest band frequency allowed (Hz).
 
@@ -32,7 +32,13 @@ class ParamSincFB(Filterbank):
     """
 
     def __init__(
-        self, n_filters, kernel_size, stride=None, sample_rate=16000, min_low_hz=50, min_band_hz=50
+        self,
+        n_filters,
+        kernel_size,
+        stride=None,
+        sample_rate=16000.0,
+        min_low_hz=50,
+        min_band_hz=50,
     ):
         if kernel_size % 2 == 0:
             print(
@@ -112,7 +118,6 @@ class ParamSincFB(Filterbank):
     def get_config(self):
         """ Returns dictionary of arguments to re-instantiate the class."""
         config = {
-            "sample_rate": self.sample_rate,
             "min_low_hz": self.min_low_hz,
             "min_band_hz": self.min_band_hz,
         }

--- a/asteroid/filterbanks/stft_fb.py
+++ b/asteroid/filterbanks/stft_fb.py
@@ -14,7 +14,7 @@ class STFTFB(Filterbank):
             (default), set to ``kernel_size // 2``.
         window (:class:`numpy.ndarray`, optional): If None, defaults to
             ``np.sqrt(np.hanning())``.
-        sample_rate (int): Sample rate of the expected audio.
+        sample_rate (float): Sample rate of the expected audio.
             Defaults to 8000.
 
     Attributes:
@@ -22,7 +22,7 @@ class STFTFB(Filterbank):
     """
 
     def __init__(
-        self, n_filters, kernel_size, stride=None, window=None, sample_rate=8000, **kwargs
+        self, n_filters, kernel_size, stride=None, window=None, sample_rate=8000.0, **kwargs
     ):
         super().__init__(n_filters, kernel_size, stride=stride, sample_rate=sample_rate)
         assert n_filters >= kernel_size

--- a/asteroid/filterbanks/stft_fb.py
+++ b/asteroid/filterbanks/stft_fb.py
@@ -14,13 +14,17 @@ class STFTFB(Filterbank):
             (default), set to ``kernel_size // 2``.
         window (:class:`numpy.ndarray`, optional): If None, defaults to
             ``np.sqrt(np.hanning())``.
+        sample_rate (int): Sample rate of the expected audio.
+            Defaults to 8000.
 
     Attributes:
         n_feats_out (int): Number of output filters.
     """
 
-    def __init__(self, n_filters, kernel_size, stride=None, window=None, **kwargs):
-        super(STFTFB, self).__init__(n_filters, kernel_size, stride=stride)
+    def __init__(
+        self, n_filters, kernel_size, stride=None, window=None, sample_rate=8000, **kwargs
+    ):
+        super().__init__(n_filters, kernel_size, stride=stride, sample_rate=sample_rate)
         assert n_filters >= kernel_size
         self.cutoff = int(n_filters / 2 + 1)
         self.n_feats_out = 2 * self.cutoff

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -20,6 +20,17 @@ def _unsqueeze_to_3d(x):
 
 
 class BaseModel(nn.Module):
+    """Base class for serializable models.
+
+    Defines saving/loading procedures as well as separation methods from
+    file, torch tensors and numpy arrays.
+    Need to overwrite the `foward` method, the `sample_rate` property and
+    the `get_model_args` method.
+    For models whose `forward` doesn't return waveform tensors,
+    overwrite `_separate` to return waveform tensors.
+
+    """
+
     def __init__(self):
         super().__init__()
 

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -224,7 +224,7 @@ class BaseEncoderMaskerDecoder(BaseModel):
         self.decoder = decoder
         self.encoder_activation = encoder_activation
         self.enc_activation = activations.get(encoder_activation or "linear")()
-        self.sample_rate = getattr(encoder, "sample_rate")
+        self.sample_rate = getattr(encoder, "sample_rate", None)
 
     def forward(self, wav):
         """Enc/Mask/Dec model forward

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -222,9 +222,9 @@ class BaseEncoderMaskerDecoder(BaseModel):
         self.encoder = encoder
         self.masker = masker
         self.decoder = decoder
-
         self.encoder_activation = encoder_activation
         self.enc_activation = activations.get(encoder_activation or "linear")()
+        self.sample_rate = getattr(encoder, "sample_rate")
 
     def forward(self, wav):
         """Enc/Mask/Dec model forward

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -26,6 +26,11 @@ class BaseModel(nn.Module):
     def forward(self, *args, **kwargs):
         raise NotImplementedError
 
+    @property
+    def sample_rate(self):
+        """Operating sample rate of the model (float)."""
+        raise NotImplementedError
+
     @torch.no_grad()
     def separate(self, wav, output_dir=None, force_overwrite=False, **kwargs):
         """Infer separated sources from input waveforms.
@@ -203,6 +208,7 @@ class BaseModel(nn.Module):
         return self.state_dict()
 
     def get_model_args(self):
+        """Should return args to re-instantiate the class."""
         raise NotImplementedError
 
 
@@ -224,7 +230,10 @@ class BaseEncoderMaskerDecoder(BaseModel):
         self.decoder = decoder
         self.encoder_activation = encoder_activation
         self.enc_activation = activations.get(encoder_activation or "linear")()
-        self.sample_rate = getattr(encoder, "sample_rate", None)
+
+    @property
+    def sample_rate(self):
+        return getattr(self.encoder, "sample_rate", None)
 
     def forward(self, wav):
         """Enc/Mask/Dec model forward


### PR DESCRIPTION
We need a way to know what is the sampling rate supported by a model. That's one attempt to do it. 


Should we enforce a `samle_rate` argument in the `BaseModel`? What would be the pros and cons? 


Is it the good place to put it in the `Filterbank` + `_EncDec`? An alternative is to place it in `BaseEncoderMaskerDecoder` (and all the child classes) but some filterbanks already have a `sample_rate` argument (param sinc and MPGT) and there would be some conflict on that. 

Any feedback is appreciated on that as it will impact pretrained models and automatic resampling in `asteroid-infer` CLI.

Linked issue #264  