### PR TITLE
Load models without sample_rate

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -15,6 +15,6 @@ jobs:
       with:
         fetch-depth: 0
     - name: Automatic Rebase
-      uses: cirrus-actions/rebase@1.2
+      uses: cirrus-actions/rebase@1.3.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/asteroid/filterbanks/__init__.py
+++ b/asteroid/filterbanks/__init__.py
@@ -12,7 +12,7 @@ def make_enc_dec(
     n_filters,
     kernel_size,
     stride=None,
-    sample_rate=8000,
+    sample_rate=8000.0,
     who_is_pinv=None,
     padding=0,
     output_padding=0,
@@ -29,8 +29,8 @@ def make_enc_dec(
         kernel_size (int): Length of the filters.
         stride (int, optional): Stride of the convolution.
             If None (default), set to ``kernel_size // 2``.
-        sample_rate (int): Sample rate of the expected audio.
-            Defaults to 8000.
+        sample_rate (float): Sample rate of the expected audio.
+            Defaults to 8000.0.
         who_is_pinv (str, optional): If `None`, no pseudo-inverse filters will
             be used. If string (among [``'encoder'``, ``'decoder'``]), decides
             which of ``Encoder`` or ``Decoder`` will be the pseudo inverse of

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -211,9 +211,9 @@ class BaseModel(nn.Module):
             sr = SR_HASHTABLE.get(pretrained_model_conf_or_path, None)
             if sr is None:
                 raise RuntimeError(
-                    "Couldn't load pretrained model without sampling rate. "
-                    "You can either pass `sample_rate` to the `from_pretrained` method or edit your model to "
-                    "include the `sample_rate` key, or use `asteroid-register-sr model sample_rate` CLI."
+                    "Couldn't load pretrained model without sampling rate. You can either pass "
+                    "`sample_rate` to the `from_pretrained` method or edit your model to include "
+                    "the `sample_rate` key, or use `asteroid-register-sr model sample_rate` CLI."
                 )
             conf["model_args"]["sample_rate"] = sr
         # Attempt to find the model and instantiate it.

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -213,7 +213,7 @@ class BaseModel(nn.Module):
                 raise RuntimeError(
                     "Couldn't load pretrained model without sampling rate. "
                     "You can either pass `sample_rate` to the `from_pretrained` method or edit your model to "
-                    "include the `sample_rate` key, or use `asteroid-register-samplerate model sample_rate` CLI."
+                    "include the `sample_rate` key, or use `asteroid-register-sr model sample_rate` CLI."
                 )
             conf["model_args"]["sample_rate"] = sr
         # Attempt to find the model and instantiate it.

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -378,7 +378,7 @@ class BaseEncoderMaskerDecoder(BaseModel):
         # Assert both dict are disjoint
         if not all(k not in fb_config for k in masknet_config):
             raise AssertionError(
-                "Filterbank and Mask network config share" "common keys. Merging them is not safe."
+                "Filterbank and Mask network config share common keys. Merging them is not safe."
             )
         # Merge all args under model_args.
         model_args = {

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -204,6 +204,18 @@ class BaseModel(nn.Module):
                 "model_args`. Found only: {}".format(conf.keys())
             )
         conf["model_args"].update(kwargs)  # kwargs overwrite config.
+        if "sample_rate" not in conf["model_args"]:
+            # Try retrieving from pretrained models
+            from ..utils.hub_utils import SR_HASHTABLE
+
+            sr = SR_HASHTABLE.get(pretrained_model_conf_or_path, None)
+            if sr is None:
+                raise RuntimeError(
+                    "Couldn't load pretrained model without sampling rate. "
+                    "You can either pass `sample_rate` to the `from_pretrained` method or edit your model to "
+                    "include the `sample_rate` key, or use `asteroid-register-samplerate model sample_rate` CLI."
+                )
+            conf["model_args"]["sample_rate"] = sr
         # Attempt to find the model and instantiate it.
         try:
             model_class = get(conf["model_name"])

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -208,7 +208,9 @@ class BaseModel(nn.Module):
             # Try retrieving from pretrained models
             from ..utils.hub_utils import SR_HASHTABLE
 
-            sr = SR_HASHTABLE.get(pretrained_model_conf_or_path, None)
+            sr = None
+            if isinstance(pretrained_model_conf_or_path, str):
+                sr = SR_HASHTABLE.get(pretrained_model_conf_or_path, None)
             if sr is None:
                 raise RuntimeError(
                     "Couldn't load pretrained model without sampling rate. You can either pass "

--- a/asteroid/models/dcunet.py
+++ b/asteroid/models/dcunet.py
@@ -54,6 +54,7 @@ class BaseDCUNet(BaseEncoderMaskerDecoder):
             "architecture": self.architecture,
             "stft_kernel_size": self.stft_kernel_size,
             "stft_stride": self.stft_stride,
+            "sample_rate": self.sample_rate,
             "masknet_kwargs": self.masknet_kwargs,
         }
         return model_args

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -164,6 +164,12 @@ class DeMask(BaseModel):
             "activation": self.activation,
             "mask_act": self.mask_act,
             "norm_type": self.norm_type,
-            **self.encoder.filterbank.get_config(),
+            "fb_type": self.fb_type,
+            "n_filters": self.n_filters,
+            "stride": self.stride,
+            "kernel_size": self.kernel_size,
+            "fb_kwargs": self.fb_kwargs,
+            "sample_rate": self.sample_rate,
         }
+        model_args.update(self.fb_kwargs)
         return model_args

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -64,6 +64,7 @@ class DeMask(BaseModel):
         self.stride = stride
         self.kernel_size = kernel_size
         self.fb_kwargs = fb_kwargs
+        self._sample_rate = sample_rate
 
         self.encoder, self.decoder = make_enc_dec(
             fb_type,
@@ -156,7 +157,7 @@ class DeMask(BaseModel):
 
     @property
     def sample_rate(self):
-        return self.sample_rate
+        return self._sample_rate
 
     def get_model_args(self):
         """ Arguments needed to re-instantiate the model. """
@@ -173,7 +174,7 @@ class DeMask(BaseModel):
             "stride": self.stride,
             "kernel_size": self.kernel_size,
             "fb_kwargs": self.fb_kwargs,
-            "sample_rate": self.sample_rate,
+            "sample_rate": self._sample_rate,
         }
         model_args.update(self.fb_kwargs)
         return model_args

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -164,11 +164,6 @@ class DeMask(BaseModel):
             "activation": self.activation,
             "mask_act": self.mask_act,
             "norm_type": self.norm_type,
-            "fb_type": self.fb_type,
-            "n_filters": self.n_filters,
-            "stride": self.stride,
-            "kernel_size": self.kernel_size,
-            "fb_kwargs": self.fb_kwargs,
+            **self.encoder.filterbank.get_config(),
         }
-        model_args.update(self.fb_kwargs)
         return model_args

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -154,6 +154,10 @@ class DeMask(BaseModel):
             return out_wavs.squeeze(0)
         return out_wavs
 
+    @property
+    def sample_rate(self):
+        return self.sample_rate
+
     def get_model_args(self):
         """ Arguments needed to re-instantiate the model. """
         model_args = {

--- a/asteroid/scripts/asteroid_cli.py
+++ b/asteroid/scripts/asteroid_cli.py
@@ -136,6 +136,26 @@ def infer():
         model.separate(f, force_overwrite=args.force_overwrite, output_dir=args.output_dir)
 
 
+def register_sample_rate():
+    """ CLI to register sample rate to an Asteroid model saved without `sample_rate`,  before 0.4.0."""
+
+    def _register_sample_rate(filename, sample_rate):
+        import torch
+
+        conf = torch.load(filename, map_location="cpu")
+        conf["model_args"]["sample_rate"] = sample_rate
+        torch.save(conf, filename)
+
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filename", type=str, help="Model file to edit.")
+    parser.add_argument("sample_rate", type=float, help="Sampling rate to add to the model.")
+    args = parser.parse_args()
+
+    _register_sample_rate(filename=args.filename, sample_rate=args.sample_rate)
+
+
 def _process_files_as_list(files_str: List) -> List:
     """ Support filename, folder name, and globs. Returns list of filenames."""
     all_files = []

--- a/asteroid/utils/hub_utils.py
+++ b/asteroid/utils/hub_utils.py
@@ -20,6 +20,8 @@ MODELS_URLS_HASHTABLE = {
     "tmirzaev-dotcom/ConvTasNet_Libri3Mix_sepnoisy": "https://zenodo.org/record/4020529/files/model.pth?download=1",
 }
 
+SR_HASHTABLE = {k: 8000.0 if not "DeMask" in k else 16000.0 for k in MODELS_URLS_HASHTABLE}
+
 
 def cached_download(filename_or_url):
     """Download from URL with torch.hub and cache the result in ASTEROID_CACHE.

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "console_scripts": [
             "asteroid-upload=asteroid.scripts.asteroid_cli:upload",
             "asteroid-infer=asteroid.scripts.asteroid_cli:infer",
+            "asteroid-register-sr=asteroid.scripts.asteroid_cli:register_sample_rate",
         ],
     },
     packages=find_packages(),

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -151,6 +151,12 @@ def _default_test_model(model, input_samples=801):
     reconstructed_model = model.__class__.from_pretrained(model_conf)
     assert_allclose(model(test_input), reconstructed_model(test_input))
 
+    # Make
+    sr = model_conf["model_args"].pop("sample_rate")
+    with pytest.raises(RuntimeError):
+        reconstructed_model = model.__class__.from_pretrained(model_conf)
+    reconstructed_model = model.__class__.from_pretrained(model_conf, sample_rate=sr)
+
 
 @pytest.mark.parametrize(
     "model", [LSTMTasNet, ConvTasNet, DPRNNTasNet, DPTNet, SuDORMRFImprovedNet, SuDORMRFNet]


### PR DESCRIPTION
This implements the loading of known models with known sample rate, and raises error when sample rate is not known. 

Also made a CLI to register sample rate to model (for the lazy ones). Is there a better name (more explicit) than `asteroid-cli register-samplerate`?

Refs: #274 #283 #284 