### PR TITLE
Rewrite forward of BaseEncoderMaskerDecoder to be more readable

### DIFF
--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -6,7 +6,7 @@ import torch
 from torch import nn
 
 from ..masknn import activations
-from ..utils.torch_utils import pad_x_to_y, script_if_tracing
+from ..utils.torch_utils import pad_x_to_y, script_if_tracing, get_shape
 from ..utils.hub_utils import cached_download
 
 
@@ -385,23 +385,6 @@ class BaseEncoderMaskerDecoder(BaseModel):
             "encoder_activation": self.encoder_activation,
         }
         return model_args
-
-
-@script_if_tracing
-def get_shape(tensor):
-    """Gets shape of `tensor` as `torch.Tensor` type for jit compiler
-
-    Note:
-        Returning `tensor.shape` of `tensor.size()` directly is not torchscript
-        compatible as return type would not be supported.
-
-    Args:
-        tensor (torch.Tensor): Tensor
-
-    Returns:
-        torch.Tensor: Shape of `tensor`
-    """
-    return torch.tensor(tensor.shape)
 
 
 @script_if_tracing

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -6,7 +6,7 @@ import torch
 from torch import nn
 
 from ..masknn import activations
-from ..utils.torch_utils import pad_x_to_y, script_if_tracing, get_shape
+from ..utils.torch_utils import pad_x_to_y, script_if_tracing, jitable_shape
 from ..utils.hub_utils import cached_download
 
 
@@ -296,7 +296,7 @@ class BaseEncoderMaskerDecoder(BaseModel):
             torch.Tensor, of shape (batch, n_src, time) or (n_src, time).
         """
         # Remember shape to shape reconstruction, cast to Tensor for torchscript
-        shape = get_shape(wav)
+        shape = jitable_shape(wav)
         # Reshape to (batch, n_mix, time)
         wav = _unsqueeze_to_3d(wav)
 

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -296,7 +296,7 @@ class BaseEncoderMaskerDecoder(BaseModel):
             torch.Tensor, of shape (batch, n_src, time) or (n_src, time).
         """
         # Remember shape to shape reconstruction, cast to Tensor for torchscript
-        shape = torch.tensor(wav.size())
+        shape = get_shape(wav)
         # Reshape to (batch, n_mix, time)
         wav = _unsqueeze_to_3d(wav)
 
@@ -385,6 +385,23 @@ class BaseEncoderMaskerDecoder(BaseModel):
             "encoder_activation": self.encoder_activation,
         }
         return model_args
+
+
+@script_if_tracing
+def get_shape(tensor):
+    """Gets shape of `tensor` as `torch.Tensor` type for jit compiler
+
+    Note:
+        Returning `tensor.shape` of `tensor.size()` directly is not torchscript
+        compatible as return type would not be supported.
+
+    Args:
+        tensor (torch.Tensor): Tensor
+
+    Returns:
+        torch.Tensor: Shape of `tensor`
+    """
+    return torch.tensor(tensor.shape)
 
 
 @script_if_tracing

--- a/asteroid/utils/torch_utils.py
+++ b/asteroid/utils/torch_utils.py
@@ -170,3 +170,20 @@ def are_models_equal(model1, model2):
         if p1.data.ne(p2.data).sum() > 0:
             return False
     return True
+
+
+@script_if_tracing
+def get_shape(tensor):
+    """Gets shape of `tensor` as `torch.Tensor` type for jit compiler
+
+    Note:
+        Returning `tensor.shape` of `tensor.size()` directly is not torchscript
+        compatible as return type would not be supported.
+
+    Args:
+        tensor (torch.Tensor): Tensor
+
+    Returns:
+        torch.Tensor: Shape of `tensor`
+    """
+    return torch.tensor(tensor.shape)

--- a/asteroid/utils/torch_utils.py
+++ b/asteroid/utils/torch_utils.py
@@ -173,7 +173,7 @@ def are_models_equal(model1, model2):
 
 
 @script_if_tracing
-def get_shape(tensor):
+def jitable_shape(tensor):
     """Gets shape of `tensor` as `torch.Tensor` type for jit compiler
 
     Note:

--- a/tests/jit/jit_torch_utils_test.py
+++ b/tests/jit/jit_torch_utils_test.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-import asteroid.utils.torch_utils as torch_utils
+from asteroid.utils import torch_utils
 
 
 @pytest.mark.parametrize(
@@ -13,8 +13,8 @@ import asteroid.utils.torch_utils as torch_utils
         torch.tensor([[2, 5], [3, 8]]),
     ),
 )
-def test_get_shape(data):
-    expected = torch_utils.get_shape(data)
-    scripted = torch.jit.trace(torch_utils.get_shape, torch.tensor([1]))
+def test_jitable_shape(data):
+    expected = torch_utils.jitable_shape(data)
+    scripted = torch.jit.trace(torch_utils.jitable_shape, torch.tensor([1]))
     output = scripted(data)
     assert torch.equal(output, expected)

--- a/tests/jit/jit_torch_utils_test.py
+++ b/tests/jit/jit_torch_utils_test.py
@@ -1,0 +1,20 @@
+import pytest
+import torch
+
+import asteroid.utils.torch_utils as torch_utils
+
+
+@pytest.mark.parametrize(
+    "data",
+    (
+        torch.tensor([1]),
+        torch.tensor([1, 2]),
+        torch.tensor([[1], [2]]),
+        torch.tensor([[2, 5], [3, 8]]),
+    ),
+)
+def test_get_shape(data):
+    expected = torch_utils.get_shape(data)
+    scripted = torch.jit.trace(torch_utils.get_shape, torch.tensor([1]))
+    output = scripted(data)
+    assert torch.equal(output, expected)

--- a/tests/utils/torch_utils_test.py
+++ b/tests/utils/torch_utils_test.py
@@ -55,3 +55,17 @@ def test_loader_submodule():
     # Apply our workaround torch_utils.load_state_dict_in and assert True.
     model_2 = torch_utils.load_state_dict_in(state_dict, model_2)
     assert torch_utils.are_models_equal(model, model_2)
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    (
+        (torch.tensor([1]), torch.tensor([1])),
+        (torch.tensor([1, 2]), torch.tensor([2])),
+        (torch.tensor([[1], [2]]), torch.tensor([2, 1])),
+        (torch.tensor([[2, 5, 5], [3, 8, -2]]), torch.tensor([2, 3])),
+    ),
+)
+def test_get_shape(data, expected):
+    output = torch_utils.get_shape(data)
+    assert torch.equal(output, expected)

--- a/tests/utils/torch_utils_test.py
+++ b/tests/utils/torch_utils_test.py
@@ -66,6 +66,6 @@ def test_loader_submodule():
         (torch.tensor([[2, 5, 5], [3, 8, -2]]), torch.tensor([2, 3])),
     ),
 )
-def test_get_shape(data, expected):
-    output = torch_utils.get_shape(data)
+def test_jitable_shape(data, expected):
+    output = torch_utils.jitable_shape(data)
     assert torch.equal(output, expected)


### PR DESCRIPTION
The step of shaping `reconstructed` is taken out of the class and turned into a torch scriptable function.

Thing I don't really like: keeping around the non squeezed version of `wav` just for reshaping.

Errors I got when I tried to avoid this issue:
* If `_shape_reconstructed` takes a tensor and a target dimension, e.g. (tensor, wav_dim), `wav_dim` is frozen during tracing and becomes a constant in the traced model. In other words, inputs of shapes other than what was seen during tracing may have the wrong output dimension
* To force the execution of `wav_dim = wav.ndim` in the traced model, I tried to write a function that just returns the `ndim` attribute of a tensor which would have been called inside `forward`. Turns out that a function that returns an `int` cannot be scripted...

If you see a more elegant solution, feel free to modify the code!