### PR TITLE
Refactor demask

### DIFF
--- a/asteroid/filterbanks/stft_fb.py
+++ b/asteroid/filterbanks/stft_fb.py
@@ -26,6 +26,8 @@ class STFTFB(Filterbank):
     ):
         super().__init__(n_filters, kernel_size, stride=stride, sample_rate=sample_rate)
         assert n_filters >= kernel_size
+        if n_filters % 2 != 0:
+            raise ValueError(f"n_filters must be even, got {n_filters}")
         self.cutoff = int(n_filters / 2 + 1)
         self.n_feats_out = 2 * self.cutoff
 

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -399,7 +399,7 @@ def _shape_reconstructed(reconstructed, size):
         torch.Tensor: Reshaped waveform
 
     """
-    if size.ndim == 1:
+    if len(size) == 1:
         return reconstructed.squeeze(0)
     return reconstructed
 

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -59,8 +59,8 @@ class DeMask(BaseEncoderMaskerDecoder):
             **fb_kwargs,
         )
 
-        n_masker_in = self._get_n_feats_input(input_type, encoder)
-        n_masker_out = self._get_n_feats_output(output_type, encoder)
+        n_masker_in = self._get_n_feats_input(input_type, encoder.n_feats_out)
+        n_masker_out = self._get_n_feats_output(output_type, encoder.n_feats_out)
         net = _build_masker_nn(
             n_masker_in,
             n_masker_out,
@@ -87,23 +87,23 @@ class DeMask(BaseEncoderMaskerDecoder):
         self.fb_kwargs = fb_kwargs
         self._sample_rate = sample_rate
 
-    def _get_n_feats_input(self, input_type, encoder):
+    def _get_n_feats_input(self, input_type, encoder_n_out):
         if input_type == "reim":
-            return encoder.n_feats_out
+            return encoder_n_out
 
         if input_type not in {"mag", "cat"}:
             raise NotImplementedError("Input type should be either mag, reim or cat")
 
-        n_feats_input = encoder.n_feats_out // 2
+        n_feats_input = encoder_n_out // 2
         if input_type == "cat":
-            n_feats_input += encoder.n_feats_out
+            n_feats_input += encoder_n_out
         return n_feats_input
 
-    def _get_n_feats_output(self, output_type, encoder):
+    def _get_n_feats_output(self, output_type, encoder_n_out):
         if output_type == "mag":
-            return encoder.n_feats_out // 2
+            return encoder_n_out // 2
         if output_type == "reim":
-            return encoder.n_feats_out
+            return encoder_n_out
         raise NotImplementedError("Output type should be either mag or reim")
 
     def forward_masker(self, tf_rep):

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -61,7 +61,7 @@ class DeMask(BaseEncoderMaskerDecoder):
 
         n_masker_in = self._get_n_feats_input(input_type, encoder.n_feats_out)
         n_masker_out = self._get_n_feats_output(output_type, encoder.n_feats_out)
-        net = _build_masker_nn(
+        masker = _build_masker_nn(
             n_masker_in,
             n_masker_out,
             norm_type=norm_type,
@@ -70,7 +70,6 @@ class DeMask(BaseEncoderMaskerDecoder):
             dropout=dropout,
             mask_act=mask_act,
         )
-        masker = nn.Sequential(*net)
         super().__init__(encoder, masker, decoder)
 
         self.input_type = input_type
@@ -187,4 +186,4 @@ def _build_masker_nn(
         in_chan = hidden_dim
 
     net.extend([nn.Conv1d(in_chan, n_out, 1), activations.get(mask_act)()])
-    return net
+    return nn.Sequential(*net)

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -125,10 +125,6 @@ class DeMask(BaseEncoderMaskerDecoder):  # CHECK-JIT
         # No need for invalid output_types as checked at init
         return est_masks
 
-    @property
-    def sample_rate(self):
-        return self._sample_rate
-
     def get_model_args(self):
         """ Arguments needed to re-instantiate the model. """
         model_args = {

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -137,7 +137,7 @@ class DeMask(BaseEncoderMaskerDecoder):
         Returns:
             torch.Tensor: Masked time-frequency representations.
         """
-        if self.output_type != "mag":
+        if self.output_type == "reim":
             tf_rep = tf_rep.unsqueeze(1)
         return est_masks * tf_rep
 

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -82,14 +82,14 @@ class DeMask(BaseModel):  # CHECK-JIT
 
     def _get_n_feats_input(self):
         if self.input_type == "reim":
-            return self.encoder.filterbank.n_filters
+            return self.encoder.n_feats_out
 
         if self.input_type not in {"mag", "cat"}:
             raise NotImplementedError("Input type should be either mag, reim or cat")
 
         n_feats_input = self.encoder.n_feats_out // 2
         if self.input_type == "cat":
-            n_feats_input += self.encoder.filterbank.n_filters
+            n_feats_input += self.encoder.n_feats_out
         return n_feats_input
 
     def _get_n_feats_output(self):

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -94,16 +94,10 @@ class DeMask(BaseModel):  # CHECK-JIT
 
     def _get_n_feats_output(self):
         if self.output_type == "mag":
-            if self.fb_type == "stft":
-                n_feats_output = self.encoder.filterbank.n_filters // 2 + 1
-            else:
-                n_feats_output = self.encoder.filterbank.n_filters // 2
-        elif self.output_type == "reim":
-            n_feats_output = self.encoder.filterbank.n_filters
-        else:
-            print("Output type should be either mag or reim")
-            raise NotImplementedError
-        return n_feats_output
+            return self.encoder.n_feats_out // 2
+        if self.output_type == "reim":
+            return self.encoder.filterbank.n_filters  # Does not seem right
+        raise NotImplementedError("Output type should be either mag or reim")
 
     def _build_masker_nn(self, n_feats_input, n_feats_output):
         make_layer_norm = norms.get(self.norm_type)

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -75,9 +75,7 @@ class DeMask(BaseModel):  # CHECK-JIT
             **fb_kwargs,
         )
 
-        n_feats_input = self._get_n_feats_input()
-        n_feats_output = self._get_n_feats_output()
-        net = self._build_masker_nn(n_feats_input, n_feats_output)
+        net = self._build_masker_nn()
         self.masker = nn.Sequential(*net)
 
     def _get_n_feats_input(self):
@@ -99,7 +97,8 @@ class DeMask(BaseModel):  # CHECK-JIT
             return self.encoder.filterbank.n_filters  # Does not seem right
         raise NotImplementedError("Output type should be either mag or reim")
 
-    def _build_masker_nn(self, n_feats_input, n_feats_output):
+    def _build_masker_nn(self):
+        n_feats_input = self._get_n_feats_input()
         make_layer_norm = norms.get(self.norm_type)
         net = [make_layer_norm(n_feats_input)]
         layer_activation = activations.get(self.activation)()
@@ -115,6 +114,7 @@ class DeMask(BaseModel):  # CHECK-JIT
             )
             in_chan = hidden_dim
 
+        n_feats_output = self._get_n_feats_output()
         net.extend([nn.Conv1d(in_chan, n_feats_output, 1), activations.get(self.mask_act)()])
         return net
 

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -75,19 +75,19 @@ class DeMask(BaseModel):  # CHECK-JIT
             **fb_kwargs,
         )
 
-        n_feats_input = self._get_n_feats_input(fb_type)
-        n_feats_output = self._get_n_feats_output(fb_type)
+        n_feats_input = self._get_n_feats_input()
+        n_feats_output = self._get_n_feats_output()
         net = self._build_masker_nn(n_feats_input, n_feats_output)
         self.masker = nn.Sequential(*net)
 
-    def _get_n_feats_input(self, fb_type):
+    def _get_n_feats_input(self):
         if self.input_type == "mag":
-            if fb_type == "stft":
+            if self.fb_type == "stft":
                 n_feats_input = (self.encoder.filterbank.n_filters) // 2 + 1
             else:
                 n_feats_input = (self.encoder.filterbank.n_filters) // 2
         elif self.input_type == "cat":
-            if fb_type == "stft":
+            if self.fb_type == "stft":
                 n_feats_input = (
                     (self.encoder.filterbank.n_filters // 2) + 1 + self.encoder.filterbank.n_filters
                 )
@@ -102,9 +102,9 @@ class DeMask(BaseModel):  # CHECK-JIT
             raise NotImplementedError
         return n_feats_input
 
-    def _get_n_feats_output(self, fb_type):
+    def _get_n_feats_output(self):
         if self.output_type == "mag":
-            if fb_type == "stft":
+            if self.fb_type == "stft":
                 n_feats_output = self.encoder.filterbank.n_filters // 2 + 1
             else:
                 n_feats_output = self.encoder.filterbank.n_filters // 2

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -77,7 +77,7 @@ class DeMask(BaseModel):  # CHECK-JIT
 
         n_feats_input = self._get_n_feats_input(fb_type)
         n_feats_output = self._get_n_feats_output(fb_type)
-        net = self._build_nn(n_feats_input, n_feats_output)
+        net = self._build_masker_nn(n_feats_input, n_feats_output)
         self.masker = nn.Sequential(*net)
 
     def _get_n_feats_input(self, fb_type):
@@ -115,7 +115,7 @@ class DeMask(BaseModel):  # CHECK-JIT
             raise NotImplementedError
         return n_feats_output
 
-    def _build_nn(self, n_feats_input, n_feats_output):
+    def _build_masker_nn(self, n_feats_input, n_feats_output):
         make_layer_norm = norms.get(self.norm_type)
         net = [make_layer_norm(n_feats_input)]
         layer_activation = activations.get(self.activation)()

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -115,7 +115,7 @@ class DeMask(BaseModel):  # CHECK-JIT
         if self.output_type == "mag":
             return self.encoder.n_feats_out // 2
         if self.output_type == "reim":
-            return self.encoder.filterbank.n_filters  # Does not seem right
+            return self.encoder.n_feats_out
         raise NotImplementedError("Output type should be either mag or reim")
 
     def forward(self, wav):

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -38,7 +38,7 @@ class DeMask(BaseEncoderMaskerDecoder):
         self,
         input_type="mag",
         output_type="mag",
-        hidden_dims=[1024],
+        hidden_dims=(1024,),
         dropout=0.0,
         activation="relu",
         mask_act="relu",

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -81,25 +81,15 @@ class DeMask(BaseModel):  # CHECK-JIT
         self.masker = nn.Sequential(*net)
 
     def _get_n_feats_input(self):
-        if self.input_type == "mag":
-            if self.fb_type == "stft":
-                n_feats_input = (self.encoder.filterbank.n_filters) // 2 + 1
-            else:
-                n_feats_input = (self.encoder.filterbank.n_filters) // 2
-        elif self.input_type == "cat":
-            if self.fb_type == "stft":
-                n_feats_input = (
-                    (self.encoder.filterbank.n_filters // 2) + 1 + self.encoder.filterbank.n_filters
-                )
-            else:
-                n_feats_input = (
-                    self.encoder.filterbank.n_filters // 2
-                ) + self.encoder.filterbank.n_filters
-        elif self.input_type == "reim":
-            n_feats_input = self.encoder.filterbank.n_filters
-        else:
-            print("Input type should be either mag, reim or cat")
-            raise NotImplementedError
+        if self.input_type == "reim":
+            return self.encoder.filterbank.n_filters
+
+        if self.input_type not in {"mag", "cat"}:
+            raise NotImplementedError("Input type should be either mag, reim or cat")
+
+        n_feats_input = self.encoder.n_feats_out // 2
+        if self.input_type == "cat":
+            n_feats_input += self.encoder.filterbank.n_filters
         return n_feats_input
 
     def _get_n_feats_output(self):

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -78,25 +78,6 @@ class DeMask(BaseModel):  # CHECK-JIT
         net = self._build_masker_nn()
         self.masker = nn.Sequential(*net)
 
-    def _get_n_feats_input(self):
-        if self.input_type == "reim":
-            return self.encoder.n_feats_out
-
-        if self.input_type not in {"mag", "cat"}:
-            raise NotImplementedError("Input type should be either mag, reim or cat")
-
-        n_feats_input = self.encoder.n_feats_out // 2
-        if self.input_type == "cat":
-            n_feats_input += self.encoder.n_feats_out
-        return n_feats_input
-
-    def _get_n_feats_output(self):
-        if self.output_type == "mag":
-            return self.encoder.n_feats_out // 2
-        if self.output_type == "reim":
-            return self.encoder.filterbank.n_filters  # Does not seem right
-        raise NotImplementedError("Output type should be either mag or reim")
-
     def _build_masker_nn(self):
         n_feats_input = self._get_n_feats_input()
         make_layer_norm = norms.get(self.norm_type)
@@ -117,6 +98,25 @@ class DeMask(BaseModel):  # CHECK-JIT
         n_feats_output = self._get_n_feats_output()
         net.extend([nn.Conv1d(in_chan, n_feats_output, 1), activations.get(self.mask_act)()])
         return net
+
+    def _get_n_feats_input(self):
+        if self.input_type == "reim":
+            return self.encoder.n_feats_out
+
+        if self.input_type not in {"mag", "cat"}:
+            raise NotImplementedError("Input type should be either mag, reim or cat")
+
+        n_feats_input = self.encoder.n_feats_out // 2
+        if self.input_type == "cat":
+            n_feats_input += self.encoder.n_feats_out
+        return n_feats_input
+
+    def _get_n_feats_output(self):
+        if self.output_type == "mag":
+            return self.encoder.n_feats_out // 2
+        if self.output_type == "reim":
+            return self.encoder.filterbank.n_filters  # Does not seem right
+        raise NotImplementedError("Output type should be either mag or reim")
 
     def forward(self, wav):
 

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -61,7 +61,7 @@ class DeMask(BaseEncoderMaskerDecoder):
 
         n_masker_in = self._get_n_feats_input(input_type, encoder.n_feats_out)
         n_masker_out = self._get_n_feats_output(output_type, encoder.n_feats_out)
-        masker = _build_masker_nn(
+        masker = build_demask_masker(
             n_masker_in,
             n_masker_out,
             norm_type=norm_type,
@@ -161,7 +161,7 @@ class DeMask(BaseEncoderMaskerDecoder):
         return model_args
 
 
-def _build_masker_nn(
+def build_demask_masker(
     n_in,
     n_out,
     activation="relu",

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -108,10 +108,10 @@ class DeMask(BaseModel):  # CHECK-JIT
                 n_feats_output = self.encoder.filterbank.n_filters // 2 + 1
             else:
                 n_feats_output = self.encoder.filterbank.n_filters // 2
-        elif self.input_type == "reim":
+        elif self.output_type == "reim":
             n_feats_output = self.encoder.filterbank.n_filters
         else:
-            print("Input type should be either mag or reim")
+            print("Output type should be either mag or reim")
             raise NotImplementedError
         return n_feats_output
 

--- a/asteroid/models/demask.py
+++ b/asteroid/models/demask.py
@@ -89,12 +89,6 @@ class DeMask(BaseEncoderMaskerDecoder):
         self.activation = activation
         self.mask_act = mask_act
         self.norm_type = norm_type
-        self.fb_type = fb_type
-        self.n_filters = n_filters
-        self.stride = stride
-        self.kernel_size = kernel_size
-        self.fb_kwargs = fb_kwargs
-        self._sample_rate = sample_rate
 
     def _get_n_feats_input(self, input_type, encoder_n_out):
         if input_type == "reim":

--- a/tests/filterbanks/stft_test.py
+++ b/tests/filterbanks/stft_test.py
@@ -31,6 +31,13 @@ def test_stft_def(fb_config):
     testing.assert_allclose(dec.filterbank.filters(), dec2.filterbank.filters())
 
 
+@pytest.mark.parametrize("n_filters", (13, 257))
+def test_stft_def_error(n_filters):
+    with pytest.raises(ValueError) as err:
+        STFTFB(n_filters, n_filters)
+    assert str(err.value) == f"n_filters must be even, got {n_filters}"
+
+
 @pytest.mark.parametrize("fb_config", fb_config_list())
 def test_stft_windows(fb_config):
     kernel_size = fb_config["kernel_size"]

--- a/tests/jit/jit_models_test.py
+++ b/tests/jit/jit_models_test.py
@@ -93,8 +93,11 @@ def small_model_params():
 @pytest.mark.parametrize(
     "test_data",
     (
+        (torch.rand(240) - 0.5) * 2,
         (torch.rand(1, 220) - 0.5) * 2,
         (torch.rand(4, 256) - 0.5) * 2,
+        (torch.rand(1, 1, 301) - 0.5) * 2,
+        (torch.rand(3, 1, 290) - 0.5) * 2,
     ),
 )
 def test_enhancement_model(small_model_params, test_data):

--- a/tests/models/demask_test.py
+++ b/tests/models/demask_test.py
@@ -115,8 +115,7 @@ def test_get_model_args():
     expected = {
         "activation": "relu",
         "dropout": 0,
-        "fb_kwargs": {},
-        "fb_type": "stft",
+        "fb_name": "STFTFB",
         "hidden_dims": (1024,),
         "input_type": "mag",
         "kernel_size": 512,

--- a/tests/models/demask_test.py
+++ b/tests/models/demask_test.py
@@ -1,0 +1,136 @@
+from glob import glob
+import os.path as osp
+import re
+
+import pytest
+import torch
+from torch.testing import assert_allclose
+
+from asteroid.models import DeMask
+
+
+# def get_input_files(dirname, prefix=''):
+#     input_files = []
+#     for file in glob(osp.join(dirname, '*.pth')):
+#         basename = osp.basename(file)
+#         if basename.startswith(prefix):
+#             input_files.append(file)
+#     input_files.sort()
+#     return input_files
+# 
+# 
+# def get_output_files(input_files, prefix='', prefix_sub=''):
+#     pattern = re.compile(f'^{prefix}')
+#     output_files = []
+#     for in_file in input_files:
+#         dirname = osp.dirname(in_file)
+#         basename = osp.basename(in_file)
+#         output_basename = pattern.sub(prefix_sub, basename)
+#         output_file = osp.join(dirname, output_basename)
+#         output_files.append(output_file)
+#     return output_files
+# 
+# 
+# def compatibility_data():
+#     model_dir = 'demask_rsc'
+#     io_data_dir = osp.join('demask_rsc', 'io_data')
+#     input_files = get_input_files(io_data_dir, prefix='input')
+#     output_files = get_output_files(
+#         input_files,
+#         prefix="input",
+#         prefix_sub="output",
+#     )
+#     return list(zip(input_files, output_files))
+# 
+# 
+# @pytest.fixture(scope='module')
+# def model():
+#     model_path = osp.join('demask_rsc', 'model.pth')
+#     return DeMask.from_pretrained(model_path, sample_rate=16000).eval()
+# 
+# 
+# @pytest.mark.parametrize('in_file, ref_file', (*compatibility_data(),))
+# def test_demask_compat(model, in_file, ref_file):
+#     in_data = torch.load(in_file)
+#     expected_data = torch.load(ref_file)
+#     with torch.no_grad():
+#         output = model(in_data)
+#         assert_allclose(output, expected_data)
+# 
+# 
+# def test_get_model_args(model):
+#     expected = {
+#         'activation': 'relu',
+#         'dropout': 0,
+#         'fb_kwargs': {},
+#         'fb_type': 'stft',
+#         'hidden_dims': [1024],
+#         'input_type': 'mag',
+#         'kernel_size': 512,
+#         'mask_act': 'relu',
+#         'n_filters': 512,
+#         'norm_type': 'gLN',
+#         'output_type': 'mag',
+#         'sample_rate': 16000,
+#         'stride': 256,
+#     }
+#     assert model.get_model_args() == expected
+
+
+@pytest.mark.parametrize("input_type", ("mag", "cat", "reim"))
+@pytest.mark.parametrize("fb_type", ("stft", "free"))
+@pytest.mark.parametrize("output_type", ("mag", "reim"))
+@pytest.mark.parametrize(
+    "data",
+    (
+        (torch.rand(130, requires_grad=False) - 0.5) * 2,
+        (torch.rand(1, 100, requires_grad=False) - 0.5) * 2,
+        (torch.rand(3, 50, requires_grad=False) - 0.5) * 2,
+        (torch.rand(1, 1, 50, requires_grad=False) - 0.5) * 2,
+        (torch.rand(2, 1, 50, requires_grad=False) - 0.5) * 2,
+    ),
+)
+def test_forward(input_type, output_type, fb_type, data):
+    demask = DeMask(
+        input_type=input_type,
+        output_type=output_type,
+        fb_type=fb_type,
+        hidden_dims=(16,),
+        kernel_size=8,
+        n_filters=8,
+        stride=4,
+    )
+    demask = demask.eval()
+    with torch.no_grad():
+        demask(data)
+
+
+def test_sample_rate():
+    demask = DeMask(
+        hidden_dims=(16,),
+        kernel_size=8,
+        n_filters=8,
+        stride=4,
+        sample_rate=9704
+    )
+    assert demask.sample_rate == 9704
+
+
+def test_get_model_args():
+    demask = DeMask()
+    expected = {
+        'activation': 'relu',
+        'dropout': 0,
+        'fb_kwargs': {},
+        'fb_type': 'stft',
+        'hidden_dims': (1024,),
+        'input_type': 'mag',
+        'kernel_size': 512,
+        'mask_act': 'relu',
+        'n_filters': 512,
+        'norm_type': 'gLN',
+        'output_type': 'mag',
+        'sample_rate': 16000,
+        'stride': 256,
+    }
+    assert demask.get_model_args() == expected

--- a/tests/models/demask_test.py
+++ b/tests/models/demask_test.py
@@ -17,8 +17,8 @@ from asteroid.models import DeMask
 #             input_files.append(file)
 #     input_files.sort()
 #     return input_files
-# 
-# 
+#
+#
 # def get_output_files(input_files, prefix='', prefix_sub=''):
 #     pattern = re.compile(f'^{prefix}')
 #     output_files = []
@@ -29,8 +29,8 @@ from asteroid.models import DeMask
 #         output_file = osp.join(dirname, output_basename)
 #         output_files.append(output_file)
 #     return output_files
-# 
-# 
+#
+#
 # def compatibility_data():
 #     model_dir = 'demask_rsc'
 #     io_data_dir = osp.join('demask_rsc', 'io_data')
@@ -41,14 +41,14 @@ from asteroid.models import DeMask
 #         prefix_sub="output",
 #     )
 #     return list(zip(input_files, output_files))
-# 
-# 
+#
+#
 # @pytest.fixture(scope='module')
 # def model():
 #     model_path = osp.join('demask_rsc', 'model.pth')
 #     return DeMask.from_pretrained(model_path, sample_rate=16000).eval()
-# 
-# 
+#
+#
 # @pytest.mark.parametrize('in_file, ref_file', (*compatibility_data(),))
 # def test_demask_compat(model, in_file, ref_file):
 #     in_data = torch.load(in_file)
@@ -56,8 +56,8 @@ from asteroid.models import DeMask
 #     with torch.no_grad():
 #         output = model(in_data)
 #         assert_allclose(output, expected_data)
-# 
-# 
+#
+#
 # def test_get_model_args(model):
 #     expected = {
 #         'activation': 'relu',
@@ -106,31 +106,25 @@ def test_forward(input_type, output_type, fb_type, data):
 
 
 def test_sample_rate():
-    demask = DeMask(
-        hidden_dims=(16,),
-        kernel_size=8,
-        n_filters=8,
-        stride=4,
-        sample_rate=9704
-    )
+    demask = DeMask(hidden_dims=(16,), kernel_size=8, n_filters=8, stride=4, sample_rate=9704)
     assert demask.sample_rate == 9704
 
 
 def test_get_model_args():
     demask = DeMask()
     expected = {
-        'activation': 'relu',
-        'dropout': 0,
-        'fb_kwargs': {},
-        'fb_type': 'stft',
-        'hidden_dims': (1024,),
-        'input_type': 'mag',
-        'kernel_size': 512,
-        'mask_act': 'relu',
-        'n_filters': 512,
-        'norm_type': 'gLN',
-        'output_type': 'mag',
-        'sample_rate': 16000,
-        'stride': 256,
+        "activation": "relu",
+        "dropout": 0,
+        "fb_kwargs": {},
+        "fb_type": "stft",
+        "hidden_dims": (1024,),
+        "input_type": "mag",
+        "kernel_size": 512,
+        "mask_act": "relu",
+        "n_filters": 512,
+        "norm_type": "gLN",
+        "output_type": "mag",
+        "sample_rate": 16000,
+        "stride": 256,
     }
     assert demask.get_model_args() == expected


### PR DESCRIPTION
Fixes #293 

Quick summary of the changes:

- [ | ] Backward compatibility tests for `DeMask`. The tests are commented at the moment while waiting for a solution to #294 
- [x] Clean up of `__init__`
- [x] Fix masker I/O dimensions when either `input_type` or `output_type` are set to `reim`
- [x] Changes to `BaseEncoderMaskerDecoder.forward` to cover what is going on inside `DeMask`:
  - [x] Add `preprocess_masker_input` hook
  - [x] Add `preprocess_product_input` hook, which processes `tf_rep` before application of `masks`
  - [x] Fix `_shape_reconstructed`: we should have tested the length of `size` instead of checking its `ndim` attribute as `ndim` of a `tensor.shape` is always 1
- [x] Make `DeMask` inherit from `BaseEncoderMaskerDecoder`
  - [x] Remove `forward`
  - [x] Rewrite `__init__`
  - [x] Override `preprocess_masker_input`, `preprocess_product_input` and `postprocess_masks`
- [   ] Check that recipe still runs
- [x] Raise error for `STFT` filter bank with odd number of filters.

:hankey: `preprocess_product_input` does not seem right, but I did not find a nicer way of making `DeMask` compatible with the forward of `BaseEncoderMaskerDecoder`. Any suggestion welcome :)!
:hankey: `DeMask` takes a `fb_type` argument while all the other model classes (and `make_enc_dec`) use a `fb_name` argument. Changing it could break backward compatibility though :/