### PR TITLE
Simplify base encoder masker decoder

### DIFF
--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -302,9 +302,7 @@ class BaseEncoderMaskerDecoder(BaseModel):
 
         # Real forward
         tf_rep = self.forward_encoder(wav)
-
-        est_masks = self.masker(tf_rep)
-        est_masks = self.postprocess_masks(est_masks)
+        est_masks = self.forward_masker(tf_rep)
 
         masked_tf_rep = est_masks * tf_rep.unsqueeze(1)
         masked_tf_rep = self.postprocess_masked(masked_tf_rep)
@@ -340,6 +338,19 @@ class BaseEncoderMaskerDecoder(BaseModel):
             Transformed `tf_rep`
         """
         return tf_rep
+
+    def forward_masker(self, tf_rep):
+        """Estimates masks from time-frequency representation.
+
+        Args:
+            tf_rep (torch.Tensor): Time-frequency representation in (batch,
+                feat, seq).
+
+        Returns:
+            torch.Tensor: Estimated masks
+        """
+        est_masks = self.masker(tf_rep)
+        return self.postprocess_masks(est_masks)
 
     def postprocess_masks(self, masks):
         """Hook to perform transformations on the masks (output of the masker) before

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -304,9 +304,7 @@ class BaseEncoderMaskerDecoder(BaseModel):
         tf_rep = self.forward_encoder(wav)
         est_masks = self.forward_masker(tf_rep)
         masked_tf_rep = self.apply_masks(tf_rep, est_masks)
-
-        decoded = self.decoder(masked_tf_rep)
-        decoded = self.postprocess_decoded(decoded)
+        decoded = self.forward_decoder(masked_tf_rep)
 
         reconstructed = pad_x_to_y(decoded, wav)
         return _shape_reconstructed(reconstructed, shape)
@@ -389,6 +387,18 @@ class BaseEncoderMaskerDecoder(BaseModel):
             Transformed `masked_tf_rep`
         """
         return masked_tf_rep
+
+    def forward_decoder(self, masked_tf_rep):
+        """Reconstructs time-domain waveforms from masked representations.
+
+        Args:
+            masked_tf_rep (torch.Tensor): Masked time-frequency representation.
+
+        Returns:
+            torch.Tensor: Time-domain waveforms.
+        """
+        decoded = self.decoder(masked_tf_rep)
+        return self.postprocess_decoded(decoded)
 
     def postprocess_decoded(self, decoded):
         """Hook to perform transformations on the decoded, time domain representation

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -301,9 +301,7 @@ class BaseEncoderMaskerDecoder(BaseModel):
         wav = _unsqueeze_to_3d(wav)
 
         # Real forward
-        tf_rep = self.encoder(wav)
-        tf_rep = self.postprocess_encoded(tf_rep)
-        tf_rep = self.enc_activation(tf_rep)
+        tf_rep = self.forward_encoder(wav)
 
         est_masks = self.masker(tf_rep)
         est_masks = self.postprocess_masks(est_masks)
@@ -316,6 +314,19 @@ class BaseEncoderMaskerDecoder(BaseModel):
 
         reconstructed = pad_x_to_y(decoded, wav)
         return _shape_reconstructed(reconstructed, shape)
+
+    def forward_encoder(self, wav):
+        """Computes time-frequency representation of `wav`.
+
+        Args:
+            wav (torch.Tensor): waveform tensor in 3D shape, time last.
+
+        Returns:
+            torch.Tensor, of shape (batch, feat, seq).
+        """
+        tf_rep = self.encoder(wav)
+        tf_rep = self.postprocess_encoded(tf_rep)
+        return self.enc_activation(tf_rep)
 
     def postprocess_encoded(self, tf_rep):
         """Hook to perform transformations on the encoded, time-frequency domain

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -303,9 +303,7 @@ class BaseEncoderMaskerDecoder(BaseModel):
         # Real forward
         tf_rep = self.forward_encoder(wav)
         est_masks = self.forward_masker(tf_rep)
-
-        masked_tf_rep = est_masks * tf_rep.unsqueeze(1)
-        masked_tf_rep = self.postprocess_masked(masked_tf_rep)
+        masked_tf_rep = self.apply_masks(tf_rep, est_masks)
 
         decoded = self.decoder(masked_tf_rep)
         decoded = self.postprocess_decoded(decoded)
@@ -364,6 +362,20 @@ class BaseEncoderMaskerDecoder(BaseModel):
             Transformed `masks`
         """
         return masks
+
+    def apply_masks(self, tf_rep, est_masks):
+        """Applies masks to time-frequency representation.
+
+        Args:
+            tf_rep (torch.Tensor): Time-frequency representation in (batch,
+                feat, seq) shape.
+            est_masks (torch.Tensor): Estimated masks.
+
+        Returns:
+            torch.Tensor: Masked time-frequency representations.
+        """
+        masked_tf_rep = est_masks * tf_rep.unsqueeze(1)
+        return self.postprocess_masked(masked_tf_rep)
 
     def postprocess_masked(self, masked_tf_rep):
         """Hook to perform transformations on the masked time-frequency domain


### PR DESCRIPTION
Simplifies structure of `BaseEncoderMaskerDecoder.forward` although the hooks are still called in the `forward_*` and `apply_masks` methods.

I am not sure about the shapes given the docstrings when they are indicated, and when they are not, it's because I didn't know if there was supposed to be an expected shape x).