### PR TITLE
Mixture Invariant Training

### DIFF
--- a/asteroid/losses/__init__.py
+++ b/asteroid/losses/__init__.py
@@ -1,4 +1,5 @@
 from .pit_wrapper import PITLossWrapper
+from .mixit_wrapper import MixITLossWrapper
 from .sinkpit_wrapper import SinkPITLossWrapper, SinkPITBetaScheduler
 from .sdr import singlesrc_neg_sisdr, multisrc_neg_sisdr
 from .sdr import singlesrc_neg_sdsdr, multisrc_neg_sdsdr
@@ -19,6 +20,7 @@ from .mse import pairwise_mse, nosrc_mse, nonpit_mse
 
 __all__ = [
     "PITLossWrapper",
+    "MixITLossWrapper",
     "SinkPITLossWrapper",
     "SinkPITBetaScheduler",
     "singlesrc_neg_sisdr",

--- a/asteroid/losses/mixit_wrapper.py
+++ b/asteroid/losses/mixit_wrapper.py
@@ -1,0 +1,258 @@
+from itertools import combinations
+import torch
+from torch import nn
+
+
+class MixITLossWrapper(nn.Module):
+    r""" Mixture invariant loss wrapper.
+
+    Args:
+        loss_func: function with signature (targets, est_targets, **kwargs).
+        pit_from (str): Determines how MixIT is applied.
+
+            * ``'mix_it'``(mixture invariant): `loss_func` computes the
+              loss for a given partition of the sources. Valid for any
+              number of mixtures as soon as they contain the same number
+              of sources.
+              Output shape : :math:`(batch)`.
+              See :meth:`~MixITLossWrapper.best_part_mix_it`.
+            * ``'mix_it_gen'``(mixture invariant generalized): `loss_func`
+              computes the loss for a given partition of the sources.
+              Valid only for two mixtures, but those mixtures do not
+              necessarly have to contain the same number of sources.
+              Output shape : :math:`(batch)`.
+              See :meth:`~MixITLossWrapper.best_part_mix_it_gen`.
+
+    For each of these modes, the best partition and reordering will be
+    automatically computed.
+
+    Examples:
+        >>> import torch
+        >>> from asteroid.losses import singlesrc_mse
+        >>> mixtures = torch.randn(10, 2, 16000)
+        >>> est_sources = torch.randn(10, 4, 16000)
+        >>> # Compute MixIT loss based on pairwise losses
+        >>> loss_func = MixITLossWrapper(singlesrc_mse, pit_from='mix_it')
+        >>> loss_val = loss_func(est_sources, mixtures)
+    """
+    def __init__(self, loss_func, pit_from='pw_mtx'):
+        super().__init__()
+        self.loss_func = loss_func
+        self.pit_from = pit_from
+        if self.pit_from not in ['mix_it', 'mix_it_gen']:
+            raise ValueError('Unsupported loss function type for now. Expected'
+                             'one of [`mix_it`, `mix_it_gen`]')
+
+    def forward(self, est_targets, targets, return_est=False, **kwargs):
+        """ Find the best partition and return the loss.
+
+        Args:
+            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+                The batch of target estimates.
+            targets: torch.Tensor. Expected shape [batch, nmix, *].
+                The batch of training targets
+            return_est: Boolean. Whether to return the estimated mixtures
+                estimates (To compute metrics or to save example).
+            **kwargs: additional keyword argument that will be passed to the
+                loss function.
+
+        Returns:
+            - Best partition loss for each batch sample, average over
+                the batch. torch.Tensor(loss_value)
+            - The estimated mixtures (estimated sources summed according
+                to the partition) if return_est is True.
+                torch.Tensor of shape [batch, nmix, *].
+        """
+
+        # check input dimensions
+        assert est_targets.shape[0] == targets.shape[0]
+        assert est_targets.shape[2] == targets.shape[2]
+
+        if self.pit_from == 'mix_it':
+            min_loss, min_loss_idx, parts = self.best_part_mix_it(
+                self.loss_func, est_targets, targets, **kwargs
+            )
+
+        elif self.pit_from == 'mix_it_gen':
+            min_loss, min_loss_idx, parts = self.best_part_mix_it_generalized(
+                self.loss_func, est_targets, targets, **kwargs
+            )
+
+        else:
+            return
+
+        # Take the mean over the batch
+        mean_loss = torch.mean(min_loss)
+        if not return_est:
+            return mean_loss
+       
+        # order sources and sum them according to the best partition to obtain the estimated mixtures
+        reordered = self.reorder_source(est_targets, targets, min_loss_idx, parts)
+        return mean_loss, reordered
+
+
+    @staticmethod
+    def best_part_mix_it(loss_func, est_targets, targets, **kwargs):
+        """ Find best partition of the estimated sources that gives
+            the minimum loss for the MixIT training paradigm in [1].
+             Valid for any number of mixtures as soon as they contain
+             the same number of sources.
+
+        Args:
+            loss_func: function with signature (targets, est_targets, **kwargs)
+                The loss function batch losses from.
+            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+                The batch of target estimates.
+            targets: torch.Tensor. Expected shape [batch, nmix, *].
+                The batch of training targets.
+            **kwargs: additional keyword argument that will be passed to the
+                loss function.
+
+        Returns:
+            tuple:
+                :class:`torch.Tensor`: The loss corresponding to the best
+                permutation of size (batch,).
+
+                :class:`torch.LongTensor`: The indexes of the best partition.
+
+                :class:`list`: list of the possible partitions of the sources.
+
+        References:
+            [1] Scott Wisdom and Efthymios Tzinis and Hakan Erdogan and Ron J Weiss
+            and Kevin Wilson and John R Hershey, "Unsupervised sound separation using
+            mixtures of mixtures." arXiv preprint arXiv:2006.12701 (2020) $
+        """
+
+        nmix = targets.shape[1]        # number of mixtures
+        nsrc = est_targets.shape[1]    # number of estimated sources
+        if nsrc % nmix != 0:
+            raise ValueError('The mixtures are assumed to contain the same number of sources')
+        nsrcmix = nsrc // nmix         # number of sources in each mixture
+
+        # Generate all unique partitions of size k from a list lst of
+        # length n, where l = n // k is the number of parts. The total
+        # number of such partitions is: NPK(n,k) = n! / ((k!)^l * l!)
+        # Algorithm recursively distributes items over parts
+        def parts_mixit(lst, k, l):
+            if l == 0:
+                yield []
+            else:
+                for c in combinations(lst, k):
+                    rest = [x for x in lst if x not in c]
+                    for r in parts_mixit(rest, k, l-1):
+                        yield [list(c), *r]
+
+        # Generate all the possible partitions
+        loss_set = []
+        parts = list(parts_mixit(range(nsrc), nsrcmix, nmix))    
+        for partition in parts:
+            assert len(partition[0]) == nsrcmix
+            assert len(partition) == nmix
+       
+            # sum the sources according to the given partition
+            est_mixes = torch.stack([torch.sum(est_targets[:, indexes, :], axis=1) for indexes in partition], axis=1)
+
+            # get loss for the given partition
+            loss_set.append(loss_func(est_mixes, targets, **kwargs)[:, None])
+
+        loss_set = torch.cat(loss_set, dim=1)
+
+        # Indexes and values of min losses for each batch element
+        min_loss, min_loss_indexes = torch.min(loss_set, dim=1, keepdim=True)
+        assert len(min_loss_indexes) == est_mixes.shape[0]
+
+        return min_loss, min_loss_indexes, parts
+
+    @staticmethod
+    def best_part_mix_it_generalized(loss_func, est_targets, targets, **kwargs):
+        """ Find best partition of the estimated sources that gives
+            the minimum loss for the MixIT training paradigm in [1].
+            Valid only for two mixtures, but those mixtures do not
+            necessarly have to contain the same number of sources.
+            It is allowed the case where one mixture is silent.
+
+        Args:
+            loss_func: function with signature (targets, est_targets, **kwargs)
+                The loss function batch losses from.
+            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+                The batch of target estimates.
+            targets: torch.Tensor. Expected shape [batch, nmix, *].
+                The batch of training targets.
+            **kwargs: additional keyword argument that will be passed to the
+                loss function.
+
+        Returns:
+            tuple:
+                :class:`torch.Tensor`: The loss corresponding to the best
+                permutation of size (batch,).
+
+                :class:`torch.LongTensor`: The indexes of the best permutations.
+
+                :class:`list`: list of the possible partitions of the sources.
+
+        References:
+            [1] Scott Wisdom and Efthymios Tzinis and Hakan Erdogan and Ron J Weiss
+            and Kevin Wilson and John R Hershey, "Unsupervised sound separation using
+            mixtures of mixtures." arXiv preprint arXiv:2006.12701 (2020) $
+        """
+
+        nmix = targets.shape[1]        # number of mixtures
+        nsrc = est_targets.shape[1]    # number of estimated sources
+        if nmix != 2:
+            raise ValueError('Works only with two mixtures')
+
+        # Generate all unique partitions of any size from a list lst of
+        # length n. Algorithm recursively distributes items over parts
+        def parts_mixit_gen(lst):
+            partitions = []
+            for k in range(len(lst) + 1):
+                for c in combinations(lst, k):
+                    rest = [x for x in lst if x not in c]
+                    partitions.append([list(c), rest]) 
+            return partitions
+
+        # Generate all the possible partitions
+        loss_set = []
+        parts = parts_mixit_gen(range(nsrc))
+        for partition in parts:
+            assert len(partition) == nmix
+        
+            # sum the sources according to the given partition
+            est_mixes = torch.stack([torch.sum(est_targets[:, indexes, :], axis=1) for indexes in partition], axis=1)
+
+            # get loss for the given partition
+            loss_set.append(loss_func(est_mixes, targets, **kwargs)[:, None])
+
+        loss_set = torch.cat(loss_set, dim=1)
+
+        # Indexes and values of min losses for each batch element
+        min_loss, min_loss_indexes = torch.min(loss_set, dim=1, keepdim=True)
+        assert len(min_loss_indexes) == est_mixes.shape[0]
+
+        return min_loss, min_loss_indexes, parts
+
+    @staticmethod
+    def reorder_source(est_targets, targets, min_loss_idx, parts):
+        """ Reorder sources according to the best partition.
+
+        Args:
+            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+                The batch of target estimates.
+            targets: torch.Tensor. Expected shape [batch, nmix, *].
+                The batch of training targets.
+            min_loss_idx: torch.LongTensor. The indexes of the best permutations.
+            parts: list of the possible partitions of the sources.
+
+        Returns:
+            :class:`torch.Tensor`:
+                Reordered sources of shape [batch, nmix, time].
+
+        """
+        # For each batch there is a different min_loss_idx
+        ordered = torch.zeros_like(targets)
+        for b, idx in enumerate(min_loss_idx):
+            right_partition = parts[idx]
+            # sum the estimated sources to get the estimated mixtures
+            ordered[b, :, :] = torch.stack([torch.sum(est_targets[b, indexes, :][None, :, :], axis=1) for indexes in right_partition], axis=1)
+
+        return ordered

--- a/asteroid/losses/mixit_wrapper.py
+++ b/asteroid/losses/mixit_wrapper.py
@@ -20,11 +20,11 @@ class MixITLossWrapper(nn.Module):
 
     Examples:
         >>> import torch
-        >>> from asteroid.losses import singlesrc_mse
+        >>> from asteroid.losses import multisrc_mse
         >>> mixtures = torch.randn(10, 2, 16000)
         >>> est_sources = torch.randn(10, 4, 16000)
         >>> # Compute MixIT loss based on pairwise losses
-        >>> loss_func = MixITLossWrapper(singlesrc_mse, generalized=True)
+        >>> loss_func = MixITLossWrapper(multisrc_mse, generalized=True)
         >>> loss_val = loss_func(est_sources, mixtures)
 
     References

--- a/asteroid/losses/mixit_wrapper.py
+++ b/asteroid/losses/mixit_wrapper.py
@@ -1,3 +1,4 @@
+import warnings
 from itertools import combinations
 import torch
 from torch import nn
@@ -24,7 +25,7 @@ class MixITLossWrapper(nn.Module):
         >>> mixtures = torch.randn(10, 2, 16000)
         >>> est_sources = torch.randn(10, 4, 16000)
         >>> # Compute MixIT loss based on pairwise losses
-        >>> loss_func = MixITLossWrapper(multisrc_mse, generalized=True)
+        >>> loss_func = MixITLossWrapper(multisrc_mse)
         >>> loss_val = loss_func(est_sources, mixtures)
 
     References
@@ -32,7 +33,7 @@ class MixITLossWrapper(nn.Module):
             mixtures of mixtures." arXiv:2006.12701 (2020)
     """
 
-    def __init__(self, loss_func, generalized=False):
+    def __init__(self, loss_func, generalized=True):
         super().__init__()
         self.loss_func = loss_func
         self.generalized = generalized

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -8,7 +8,7 @@ class PITLossWrapper(nn.Module):
     r"""Permutation invariant loss wrapper.
 
     Args:
-        loss_func: function with signature (targets, est_targets, **kwargs).
+        loss_func: function with signature (est_targets, targets, **kwargs).
         pit_from (str): Determines how PIT is applied.
 
             * ``'pw_mtx'`` (pairwise matrix): `loss_func` computes pairwise
@@ -135,7 +135,7 @@ class PITLossWrapper(nn.Module):
         for a given loss function.
 
         Args:
-            loss_func: function with signature (targets, est_targets, **kwargs)
+            loss_func: function with signature (est_targets, targets, **kwargs)
                 The loss function to get pair-wise losses from.
             est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
                 The batch of target estimates.
@@ -164,7 +164,7 @@ class PITLossWrapper(nn.Module):
         """Find best permutation from loss function with source axis.
 
         Args:
-            loss_func: function with signature (targets, est_targets, **kwargs)
+            loss_func: function with signature (est_targets, targets, **kwargs)
                 The loss function batch losses from.
             est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
                 The batch of target estimates.

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -4,7 +4,7 @@ from torch import nn
 
 
 class PITLossWrapper(nn.Module):
-    """ Permutation invariant loss wrapper.
+    r""" Permutation invariant loss wrapper.
 
     Args:
         loss_func: function with signature (targets, est_targets, **kwargs).

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -1,11 +1,10 @@
-from itertools import permutations
+from itertools import permutations, combinations
 import torch
 from torch import nn
-from scipy.optimize import linear_sum_assignment
 
 
 class PITLossWrapper(nn.Module):
-    r"""Permutation invariant loss wrapper.
+    """ Permutation invariant loss wrapper.
 
     Args:
         loss_func: function with signature (targets, est_targets, **kwargs).
@@ -24,6 +23,18 @@ class PITLossWrapper(nn.Module):
               average loss for a given permutations of the sources and
               estimates. Output shape : :math:`(batch)`.
               See :meth:`~PITLossWrapper.best_perm_from_perm_avg_loss`.
+            * ``'mix_it'``(mixture invariant): `loss_func` computes the
+              loss for a given partition of the sources. Valid for any
+              number of mixtures as soon as they contain the same number
+              of sources.
+              Output shape : :math:`(batch)`.
+              See :meth:`~PITLossWrapper.best_part_mix_it`.
+            * ``'mix_it_gen'``(mixture invariant generalized): `loss_func`
+              computes the loss for a given partition of the sources.
+              Valid only for two mixtures, but those mixtures do not
+              necessarly have to contain the same number of sources.
+              Output shape : :math:`(batch)`.
+              See :meth:`~PITLossWrapper.best_part_mix_it_gen`.
 
             In terms of efficiency, ``'perm_avg'`` is the least efficicient.
 
@@ -38,7 +49,7 @@ class PITLossWrapper(nn.Module):
     For each of these modes, the best permutation and reordering will be
     automatically computed.
 
-    Examples
+    Examples:
         >>> import torch
         >>> from asteroid.losses import pairwise_neg_sisdr
         >>> sources = torch.randn(10, 3, 16000)
@@ -58,20 +69,18 @@ class PITLossWrapper(nn.Module):
         >>> loss_val = loss_func(est_sources, sources,
         >>>                      reduce_kwargs=reduce_kwargs)
     """
-
-    def __init__(self, loss_func, pit_from="pw_mtx", perm_reduce=None):
+    def __init__(self, loss_func, pit_from='pw_mtx', perm_reduce=None):
         super().__init__()
         self.loss_func = loss_func
         self.pit_from = pit_from
         self.perm_reduce = perm_reduce
-        if self.pit_from not in ["pw_mtx", "pw_pt", "perm_avg"]:
-            raise ValueError(
-                "Unsupported loss function type for now. Expected"
-                "one of [`pw_mtx`, `pw_pt`, `perm_avg`]"
-            )
+        if self.pit_from not in ['pw_mtx', 'pw_pt', 'perm_avg', 'mix_it', 'mix_it_gen']:
+            raise ValueError('Unsupported loss function type for now. Expected'
+                             'one of [`pw_mtx`, `pw_pt`, `perm_avg`, `mix_it`, `mix_it_gen`]')
 
-    def forward(self, est_targets, targets, return_est=False, reduce_kwargs=None, **kwargs):
-        """Find the best permutation and return the loss.
+    def forward(self, est_targets, targets, return_est=False,
+                reduce_kwargs=None, **kwargs):
+        """ Find the best permutation and return the loss.
 
         Args:
             est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
@@ -93,45 +102,68 @@ class PITLossWrapper(nn.Module):
         """
         n_src = targets.shape[1]
         assert n_src < 10, f"Expected source axis along dim 1, found {n_src}"
-        if self.pit_from == "pw_mtx":
+        if self.pit_from == 'pw_mtx':
             # Loss function already returns pairwise losses
             pw_losses = self.loss_func(est_targets, targets, **kwargs)
-        elif self.pit_from == "pw_pt":
+        elif self.pit_from == 'pw_pt':
             # Compute pairwise losses with a for loop.
-            pw_losses = self.get_pw_losses(self.loss_func, est_targets, targets, **kwargs)
-        elif self.pit_from == "perm_avg":
+            pw_losses = self.get_pw_losses(self.loss_func, est_targets,
+                                           targets, **kwargs)
+
+        elif self.pit_from == 'perm_avg':
             # Cannot get pairwise losses from this type of loss.
             # Find best permutation directly.
-            min_loss, batch_indices = self.best_perm_from_perm_avg_loss(
+            min_loss, min_loss_idx = self.best_perm_from_perm_avg_loss(
                 self.loss_func, est_targets, targets, **kwargs
             )
             # Take the mean over the batch
             mean_loss = torch.mean(min_loss)
             if not return_est:
                 return mean_loss
-            reordered = self.reorder_source(est_targets, batch_indices)
+            reordered = self.reorder_source(est_targets, n_src, min_loss_idx)
             return mean_loss, reordered
+
+        elif self.pit_from == 'mix_it':
+            # Cannot get pairwise losses from this type of loss.
+            # Find best permutation and return ordered sources directly.
+            min_loss, reordered = self.best_part_mix_it(
+                self.loss_func, est_targets, targets, **kwargs
+            )
+            # Take the mean over the batch
+            mean_loss = torch.mean(min_loss)
+            return mean_loss, reordered
+
+        elif self.pit_from == 'mix_it_gen':
+            # Cannot get pairwise losses from this type of loss.
+            # Find best permutation and return ordered sources directly.
+            min_loss, reordered = self.best_part_mix_it_generalized(
+                self.loss_func, est_targets, targets, **kwargs
+            )
+            # Take the mean over the batch
+            mean_loss = torch.mean(min_loss)
+            return mean_loss, reordered
+
         else:
             return
 
-        assert pw_losses.ndim == 3, (
-            "Something went wrong with the loss " "function, please read the docs."
-        )
-        assert pw_losses.shape[0] == targets.shape[0], "PIT loss needs same batch dim as input"
+        assert pw_losses.ndim == 3, ("Something went wrong with the loss "
+                                     "function, please read the docs.")
+        assert (pw_losses.shape[0] ==
+                targets.shape[0]), "PIT loss needs same batch dim as input"
 
         reduce_kwargs = reduce_kwargs if reduce_kwargs is not None else dict()
-        min_loss, batch_indices = self.find_best_perm(
-            pw_losses, perm_reduce=self.perm_reduce, **reduce_kwargs
+        min_loss, min_loss_idx = self.find_best_perm(
+            pw_losses, n_src, perm_reduce=self.perm_reduce, **reduce_kwargs
         )
         mean_loss = torch.mean(min_loss)
         if not return_est:
             return mean_loss
-        reordered = self.reorder_source(est_targets, batch_indices)
+        reordered = self.reorder_source(est_targets, n_src, min_loss_idx)
         return mean_loss, reordered
 
     @staticmethod
     def get_pw_losses(loss_func, est_targets, targets, **kwargs):
-        """Get pair-wise losses between the training targets and its estimate
+        """ Get pair-wise losses between the training targets and its estimate
         for a given loss function.
 
         Args:
@@ -156,12 +188,13 @@ class PITLossWrapper(nn.Module):
         pair_wise_losses = targets.new_empty(batch_size, n_src, n_src)
         for est_idx, est_src in enumerate(est_targets.transpose(0, 1)):
             for target_idx, target_src in enumerate(targets.transpose(0, 1)):
-                pair_wise_losses[:, est_idx, target_idx] = loss_func(est_src, target_src, **kwargs)
+                pair_wise_losses[:, est_idx, target_idx] = loss_func(
+                    est_src, target_src, **kwargs)
         return pair_wise_losses
 
     @staticmethod
     def best_perm_from_perm_avg_loss(loss_func, est_targets, targets, **kwargs):
-        """Find best permutation from loss function with source axis.
+        """ Find best permutation from loss function with source axis.
 
         Args:
             loss_func: function with signature (targets, est_targets, **kwargs)
@@ -178,30 +211,187 @@ class PITLossWrapper(nn.Module):
                 :class:`torch.Tensor`: The loss corresponding to the best
                 permutation of size (batch,).
 
-                :class:`torch.Tensor`: The indices of the best permutations.
+                :class:`torch.LongTensor`: The indexes of the best permutations.
         """
         n_src = targets.shape[1]
-        perms = torch.tensor(list(permutations(range(n_src))), dtype=torch.long)
-        loss_set = torch.stack(
-            [loss_func(est_targets[:, perm], targets, **kwargs) for perm in perms], dim=1
-        )
+        perms = list(permutations(range(n_src)))
+        loss_set = torch.stack([loss_func(est_targets[:, perm],
+                                          targets,
+                                          **kwargs) for perm in perms],
+                               dim=1)
         # Indexes and values of min losses for each batch element
-        min_loss, min_loss_idx = torch.min(loss_set, dim=1)
-        # Permutation indices for each batch.
-        batch_indices = torch.stack([perms[m] for m in min_loss_idx], dim=0)
-        return min_loss, batch_indices
+        min_loss, min_loss_idx = torch.min(loss_set, dim=1, keepdim=True)
+        return min_loss, min_loss_idx[:, 0]
 
     @staticmethod
-    def find_best_perm(pair_wise_losses, perm_reduce=None, **kwargs):
+    def best_part_mix_it(loss_func, est_targets, targets, **kwargs):
+        """ Find best partition of the estimated sources that gives
+            the minimum loss for the MixIT training paradigm in [1].
+             Valid for any number of mixtures as soon as they contain
+             the same number of sources.
+
+        Args:
+            loss_func: function with signature (targets, est_targets, **kwargs)
+                The loss function batch losses from.
+            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+                The batch of target estimates.
+            targets: torch.Tensor. Expected shape [batch, nsrc, *].
+                The batch of training targets.
+            **kwargs: additional keyword argument that will be passed to the
+                loss function.
+
+        Returns:
+            tuple:
+                :class:`torch.Tensor`: The loss corresponding to the best
+                permutation of size (batch,).
+
+                :class:`torch.LongTensor`: The indexes of the best permutations.
+
+        References:
+            [1] Scott Wisdom and Efthymios Tzinis and Hakan Erdogan and Ron J Weiss
+            and Kevin Wilson and John R Hershey, "Unsupervised sound separation using
+            mixtures of mixtures." arXiv preprint arXiv:2006.12701 (2020) $
+        """
+
+        # check input dimensions
+        assert est_targets.shape[0] == targets.shape[0]
+        assert est_targets.shape[2] == targets.shape[2]
+
+        # get L, N and M
+        L = targets.shape[1]        # number of mixtures 
+        N = est_targets.shape[1]    # number of estimated sources
+        if N % L != 0:
+            raise ValueError('The mixtures are assumed to contain the same number of sources')
+        M = N // L                  # number of sources in each mixture
+
+        # Generate all unique partitions of size k from a list lst of
+        # length n, where l = n // k is the number of parts. The total
+        # number of such partitions is: NPK(n,k) = n! / ((k!)^l * l!)
+        # Algorithm recursively distributes items over parts
+        def combs(lst, k, l):
+            if l == 0:
+                yield []
+            else:
+                for c in combinations(lst, k):
+                    rest = [x for x in lst if x not in c]
+                    for r in combs(rest, k, l-1):
+                        yield [list(c), *r]
+
+        # Generate all the possible partitions
+        parts = list(combs(range(N), M, L))     
+        for p, partition in enumerate(parts):
+            assert len(partition[0]) == M
+            assert len(partition) == L
+        
+            # sum the sources according to the given partition
+            est_mixes = torch.stack([torch.sum(est_targets[:, indexes, :], axis=1) for indexes in partition], axis=1)
+
+            # get loss for the given partition
+            if p == 0:
+                loss_set = loss_func(est_mixes, targets, **kwargs)[:, None]
+            else:
+                loss_set = torch.cat([loss_set, loss_func(est_mixes, targets, **kwargs)[:, None]], dim=1)
+
+        # Indexes and values of min losses for each batch element
+        min_loss, min_loss_indexes = torch.min(loss_set, dim=1, keepdim=True)
+        assert len(min_loss_indexes) == est_mixes.shape[0]
+
+        # For each batch there is a different min_loss_idx
+        ordered = torch.zeros_like(est_mixes)
+        for b, idx in enumerate(min_loss_indexes):
+            right_partition = parts[idx]
+            # sum the estimated sources to get the estimated mixtures
+            ordered[b, :, :] = torch.stack([torch.sum(est_targets[b, indexes, :][None, :, :], axis=1) for indexes in right_partition], axis=1)
+
+        return min_loss, ordered
+
+    @staticmethod
+    def best_part_mix_it_generalized(loss_func, est_targets, targets, **kwargs):
+        """ Find best partition of the estimated sources that gives
+            the minimum loss for the MixIT training paradigm in [1].
+            Valid only for two mixtures, but those mixtures do not
+            necessarly have to contain the same number of sources.
+            It is allowed the case where one mixture is silent.
+
+        Args:
+            loss_func: function with signature (targets, est_targets, **kwargs)
+                The loss function batch losses from.
+            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+                The batch of target estimates.
+            targets: torch.Tensor. Expected shape [batch, nsrc, *].
+                The batch of training targets.
+            **kwargs: additional keyword argument that will be passed to the
+                loss function.
+
+        Returns:
+            tuple:
+                :class:`torch.Tensor`: The loss corresponding to the best
+                permutation of size (batch,).
+
+                :class:`torch.LongTensor`: The indexes of the best permutations.
+
+        References:
+            [1] Scott Wisdom and Efthymios Tzinis and Hakan Erdogan and Ron J Weiss
+            and Kevin Wilson and John R Hershey, "Unsupervised sound separation using
+            mixtures of mixtures." arXiv preprint arXiv:2006.12701 (2020) $
+        """
+
+        # check input dimensions
+        assert est_targets.shape[0] == targets.shape[0]
+        assert est_targets.shape[2] == targets.shape[2]
+
+        # get L, N and M
+        L = targets.shape[1]        # number of mixtures 
+        N = est_targets.shape[1]    # number of estimated sources
+
+        if L != 2:
+            raise ValueError('Works only with two mixtures')
+
+        # Generate all unique partitions of any size from a list lst of
+        # length n. Algorithm recursively distributes items over parts
+        def all_combinations(lst):
+            all_combinations = []
+            for k in range(len(lst) + 1):
+                for c in combinations(lst, k):
+                    rest = [x for x in lst if x not in c]
+                    all_combinations.append([list(c), rest]) 
+            return all_combinations
+
+        # Generate all the possible partitions
+        parts = all_combinations(range(N))    
+        for p, partition in enumerate(parts):
+            assert len(partition) == L
+        
+            # sum the sources according to the given partition
+            est_mixes = torch.stack([torch.sum(est_targets[:, indexes, :], axis=1) for indexes in partition], axis=1)
+
+            # get loss for the given partition
+            if p == 0:
+                loss_set = loss_func(est_mixes, targets, **kwargs)[:, None]
+            else:
+                loss_set = torch.cat([loss_set, loss_func(est_mixes, targets, **kwargs)[:, None]], dim=1)
+
+        # Indexes and values of min losses for each batch element
+        min_loss, min_loss_indexes = torch.min(loss_set, dim=1, keepdim=True)
+        assert len(min_loss_indexes) == est_mixes.shape[0]
+
+        # For each batch there is a different min_loss_idx
+        ordered = torch.zeros_like(est_mixes)
+        for b, idx in enumerate(min_loss_indexes):
+            right_partition = parts[idx]
+            # sum the estimated sources to get the estimated mixtures
+            ordered[b, :, :] = torch.stack([torch.sum(est_targets[b, indexes, :][None, :, :], axis=1) for indexes in right_partition], axis=1)
+
+        return min_loss, ordered
+
+    @staticmethod
+    def find_best_perm(pair_wise_losses, n_src, perm_reduce=None, **kwargs):
         """Find the best permutation, given the pair-wise losses.
 
-        Dispatch between factorial method if number of sources is small (<3)
-        and hungarian method for more sources. If `perm_reduce` is not None,
-        the factorial method is always used.
-
         Args:
             pair_wise_losses (:class:`torch.Tensor`):
                 Tensor of shape [batch, n_src, n_src]. Pairwise losses.
+            n_src (int): Number of sources.
             perm_reduce (Callable): torch function to reduce permutation losses.
                 Defaults to None (equivalent to mean). Signature of the func
                 (pwl_set, **kwargs) : (B, n_src!, n_src) --> (B, n_src!)
@@ -213,124 +403,63 @@ class PITLossWrapper(nn.Module):
                 :class:`torch.Tensor`: The loss corresponding to the best
                 permutation of size (batch,).
 
-                :class:`torch.Tensor`: The indices of the best permutations.
-        """
-        n_src = pair_wise_losses.shape[-1]
-        if perm_reduce is not None or n_src <= 3:
-            min_loss, batch_indices = PITLossWrapper.find_best_perm_factorial(
-                pair_wise_losses, perm_reduce=perm_reduce, **kwargs
-            )
-        else:
-            min_loss, batch_indices = PITLossWrapper.find_best_perm_hungarian(pair_wise_losses)
-        return min_loss, batch_indices
-
-    @staticmethod
-    def reorder_source(source, batch_indices):
-        """Reorder sources according to the best permutation.
-
-        Args:
-            source (torch.Tensor): Tensor of shape [batch, n_src, time]
-            batch_indices (torch.Tensor): Tensor of shape [batch, n_src].
-                Contains optimal permutation indices for each batch.
-
-        Returns:
-            :class:`torch.Tensor`:
-                Reordered sources of shape [batch, n_src, time].
-        """
-        reordered_sources = torch.stack(
-            [torch.index_select(s, 0, b) for s, b in zip(source, batch_indices)]
-        )
-        return reordered_sources
-
-    @staticmethod
-    def find_best_perm_factorial(pair_wise_losses, perm_reduce=None, **kwargs):
-        """Find the best permutation given the pair-wise losses by looping
-        through all the permutations.
-
-        Args:
-            pair_wise_losses (:class:`torch.Tensor`):
-                Tensor of shape [batch, n_src, n_src]. Pairwise losses.
-            perm_reduce (Callable): torch function to reduce permutation losses.
-                Defaults to None (equivalent to mean). Signature of the func
-                (pwl_set, **kwargs) : (B, n_src!, n_src) --> (B, n_src!)
-            **kwargs: additional keyword argument that will be passed to the
-                permutation reduce function.
-
-        Returns:
-            tuple:
-                :class:`torch.Tensor`: The loss corresponding to the best
-                permutation of size (batch,).
-
-                :class:`torch.Tensor`: The indices of the best permutations.
+                :class:`torch.LongTensor`: The indexes of the best permutations.
 
         MIT Copyright (c) 2018 Kaituo XU.
         See `Original code
         <https://github.com/kaituoxu/Conv-TasNet/blob/master>`__ and `License
         <https://github.com/kaituoxu/Conv-TasNet/blob/master/LICENSE>`__.
         """
-        n_src = pair_wise_losses.shape[-1]
         # After transposition, dim 1 corresp. to sources and dim 2 to estimates
         pwl = pair_wise_losses.transpose(-1, -2)
-        perms = pwl.new_tensor(list(permutations(range(n_src))), dtype=torch.long)
+        perms = pwl.new_tensor(list(permutations(range(n_src))),
+                               dtype=torch.long)
         # Column permutation indices
         idx = torch.unsqueeze(perms, 2)
         # Loss mean of each permutation
         if perm_reduce is None:
             # one-hot, [n_src!, n_src, n_src]
             perms_one_hot = pwl.new_zeros((*perms.size(), n_src)).scatter_(2, idx, 1)
-            loss_set = torch.einsum("bij,pij->bp", [pwl, perms_one_hot])
+            loss_set = torch.einsum('bij,pij->bp', [pwl, perms_one_hot])
             loss_set /= n_src
         else:
-            # batch = pwl.shape[0]; n_perm = idx.shape[0]
+            batch = pwl.shape[0]
+            n_perm = idx.shape[0]
             # [batch, n_src!, n_src] : Pairwise losses for each permutation.
             pwl_set = pwl[:, torch.arange(n_src), idx.squeeze(-1)]
             # Apply reduce [batch, n_src!, n_src] --> [batch, n_src!]
             loss_set = perm_reduce(pwl_set, **kwargs)
         # Indexes and values of min losses for each batch element
-        min_loss, min_loss_idx = torch.min(loss_set, dim=1)
-
-        # Permutation indices for each batch.
-        batch_indices = torch.stack([perms[m] for m in min_loss_idx], dim=0)
-        return min_loss, batch_indices
+        min_loss_idx = torch.argmin(loss_set, dim=1)
+        min_loss, _ = torch.min(loss_set, dim=1, keepdim=True)
+        return min_loss, min_loss_idx
 
     @staticmethod
-    def find_best_perm_hungarian(pair_wise_losses: torch.Tensor):
-        """Find the best permutation given the pair-wise losses, using the
-        Hungarian algorithm.
+    def reorder_source(source, n_src, min_loss_idx):
+        """ Reorder sources according to the best permutation.
 
         Args:
-            pair_wise_losses (:class:`torch.Tensor`):
-                Tensor of shape [batch, n_src, n_src]. Pairwise losses.
+            source (torch.Tensor): Tensor of shape [batch, n_src, time]
+            n_src (int): Number of sources.
+            min_loss_idx (torch.LongTensor): Tensor of shape [batch],
+                each item is in [0, n_src!).
 
         Returns:
-            tuple:
-                :class:`torch.Tensor`: The loss corresponding to the best
-                permutation of size (batch,).
+            :class:`torch.Tensor`:
+                Reordered sources of shape [batch, n_src, time].
 
-                :class:`torch.Tensor`: The indices of the best permutations.
+        MIT Copyright (c) 2018 Kaituo XU.
+        See `Original code
+        <https://github.com/kaituoxu/Conv-TasNet/blob/master>`__ and `License
+        <https://github.com/kaituoxu/Conv-TasNet/blob/master/LICENSE>`__.
         """
-        # After transposition, dim 1 corresp. to sources and dim 2 to estimates
-        pwl = pair_wise_losses.transpose(-1, -2)
-        # Just bring the numbers to cpu(), not the graph
-        pwl_copy = pwl.detach().cpu()
-        # Loop over batch + row indices are always ordered for square matrices.
-        batch_indices = torch.tensor([linear_sum_assignment(pwl)[1] for pwl in pwl_copy]).to(
-            pwl.device
-        )
-        min_loss = torch.gather(pwl, 2, batch_indices[..., None]).mean([-1, -2])
-        return min_loss, batch_indices
-
-
-class PITReorder(PITLossWrapper):
-    """Permutation invariant reorderer. Only returns the reordered estimates.
-    See `:py:class:asteroid.losses.PITLossWrapper`."""
-
-    def forward(self, est_targets, targets, reduce_kwargs=None, **kwargs):
-        _, reordered = super().forward(
-            est_targets=est_targets,
-            targets=targets,
-            return_est=True,
-            reduce_kwargs=reduce_kwargs,
-            **kwargs,
-        )
-        return reordered
+        perms = source.new_tensor(list(permutations(range(n_src))),
+                                  dtype=torch.long)
+        # Reorder estimate targets according the best permutation
+        min_loss_perm = torch.index_select(perms, dim=0, index=min_loss_idx)
+        # maybe use torch.gather()/index_select()/scatter() to impl this?
+        reordered_sources = torch.zeros_like(source)
+        for b in range(source.shape[0]):
+            for c in range(n_src):
+                reordered_sources[b, c] = source[b, min_loss_perm[b][c]]
+        return reordered_sources

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -1,10 +1,11 @@
 from itertools import permutations, combinations
 import torch
 from torch import nn
+from scipy.optimize import linear_sum_assignment
 
 
 class PITLossWrapper(nn.Module):
-    r""" Permutation invariant loss wrapper.
+    r"""Permutation invariant loss wrapper.
 
     Args:
         loss_func: function with signature (targets, est_targets, **kwargs).
@@ -49,7 +50,7 @@ class PITLossWrapper(nn.Module):
     For each of these modes, the best permutation and reordering will be
     automatically computed.
 
-    Examples:
+    Examples
         >>> import torch
         >>> from asteroid.losses import pairwise_neg_sisdr
         >>> sources = torch.randn(10, 3, 16000)
@@ -69,18 +70,20 @@ class PITLossWrapper(nn.Module):
         >>> loss_val = loss_func(est_sources, sources,
         >>>                      reduce_kwargs=reduce_kwargs)
     """
-    def __init__(self, loss_func, pit_from='pw_mtx', perm_reduce=None):
+
+    def __init__(self, loss_func, pit_from="pw_mtx", perm_reduce=None):
         super().__init__()
         self.loss_func = loss_func
         self.pit_from = pit_from
         self.perm_reduce = perm_reduce
         if self.pit_from not in ['pw_mtx', 'pw_pt', 'perm_avg', 'mix_it', 'mix_it_gen']:
-            raise ValueError('Unsupported loss function type for now. Expected'
-                             'one of [`pw_mtx`, `pw_pt`, `perm_avg`, `mix_it`, `mix_it_gen`]')
+            raise ValueError(
+                "Unsupported loss function type for now. Expected"
+                "one of [`pw_mtx`, `pw_pt`, `perm_avg`, `mix_it`, `mix_it_gen`]"
+            )
 
-    def forward(self, est_targets, targets, return_est=False,
-                reduce_kwargs=None, **kwargs):
-        """ Find the best permutation and return the loss.
+    def forward(self, est_targets, targets, return_est=False, reduce_kwargs=None, **kwargs):
+        """Find the best permutation and return the loss.
 
         Args:
             est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
@@ -102,27 +105,24 @@ class PITLossWrapper(nn.Module):
         """
         n_src = targets.shape[1]
         assert n_src < 10, f"Expected source axis along dim 1, found {n_src}"
-        if self.pit_from == 'pw_mtx':
+        if self.pit_from == "pw_mtx":
             # Loss function already returns pairwise losses
             pw_losses = self.loss_func(est_targets, targets, **kwargs)
-        elif self.pit_from == 'pw_pt':
+        elif self.pit_from == "pw_pt":
             # Compute pairwise losses with a for loop.
-            pw_losses = self.get_pw_losses(self.loss_func, est_targets,
-                                           targets, **kwargs)
-
-        elif self.pit_from == 'perm_avg':
+            pw_losses = self.get_pw_losses(self.loss_func, est_targets, targets, **kwargs)
+        elif self.pit_from == "perm_avg":
             # Cannot get pairwise losses from this type of loss.
             # Find best permutation directly.
-            min_loss, min_loss_idx = self.best_perm_from_perm_avg_loss(
+            min_loss, batch_indices = self.best_perm_from_perm_avg_loss(
                 self.loss_func, est_targets, targets, **kwargs
             )
             # Take the mean over the batch
             mean_loss = torch.mean(min_loss)
             if not return_est:
                 return mean_loss
-            reordered = self.reorder_source(est_targets, n_src, min_loss_idx)
+            reordered = self.reorder_source(est_targets, batch_indices)
             return mean_loss, reordered
-
         elif self.pit_from == 'mix_it':
             # Cannot get pairwise losses from this type of loss.
             # Find best permutation and return ordered sources directly.
@@ -132,7 +132,6 @@ class PITLossWrapper(nn.Module):
             # Take the mean over the batch
             mean_loss = torch.mean(min_loss)
             return mean_loss, reordered
-
         elif self.pit_from == 'mix_it_gen':
             # Cannot get pairwise losses from this type of loss.
             # Find best permutation and return ordered sources directly.
@@ -142,28 +141,27 @@ class PITLossWrapper(nn.Module):
             # Take the mean over the batch
             mean_loss = torch.mean(min_loss)
             return mean_loss, reordered
-
         else:
             return
 
-        assert pw_losses.ndim == 3, ("Something went wrong with the loss "
-                                     "function, please read the docs.")
-        assert (pw_losses.shape[0] ==
-                targets.shape[0]), "PIT loss needs same batch dim as input"
+        assert pw_losses.ndim == 3, (
+            "Something went wrong with the loss " "function, please read the docs."
+        )
+        assert pw_losses.shape[0] == targets.shape[0], "PIT loss needs same batch dim as input"
 
         reduce_kwargs = reduce_kwargs if reduce_kwargs is not None else dict()
-        min_loss, min_loss_idx = self.find_best_perm(
-            pw_losses, n_src, perm_reduce=self.perm_reduce, **reduce_kwargs
+        min_loss, batch_indices = self.find_best_perm(
+            pw_losses, perm_reduce=self.perm_reduce, **reduce_kwargs
         )
         mean_loss = torch.mean(min_loss)
         if not return_est:
             return mean_loss
-        reordered = self.reorder_source(est_targets, n_src, min_loss_idx)
+        reordered = self.reorder_source(est_targets, batch_indices)
         return mean_loss, reordered
 
     @staticmethod
     def get_pw_losses(loss_func, est_targets, targets, **kwargs):
-        """ Get pair-wise losses between the training targets and its estimate
+        """Get pair-wise losses between the training targets and its estimate
         for a given loss function.
 
         Args:
@@ -188,13 +186,12 @@ class PITLossWrapper(nn.Module):
         pair_wise_losses = targets.new_empty(batch_size, n_src, n_src)
         for est_idx, est_src in enumerate(est_targets.transpose(0, 1)):
             for target_idx, target_src in enumerate(targets.transpose(0, 1)):
-                pair_wise_losses[:, est_idx, target_idx] = loss_func(
-                    est_src, target_src, **kwargs)
+                pair_wise_losses[:, est_idx, target_idx] = loss_func(est_src, target_src, **kwargs)
         return pair_wise_losses
 
     @staticmethod
     def best_perm_from_perm_avg_loss(loss_func, est_targets, targets, **kwargs):
-        """ Find best permutation from loss function with source axis.
+        """Find best permutation from loss function with source axis.
 
         Args:
             loss_func: function with signature (targets, est_targets, **kwargs)
@@ -211,18 +208,21 @@ class PITLossWrapper(nn.Module):
                 :class:`torch.Tensor`: The loss corresponding to the best
                 permutation of size (batch,).
 
-                :class:`torch.LongTensor`: The indexes of the best permutations.
+                :class:`torch.Tensor`: The indices of the best permutations.
         """
         n_src = targets.shape[1]
-        perms = list(permutations(range(n_src)))
-        loss_set = torch.stack([loss_func(est_targets[:, perm],
-                                          targets,
-                                          **kwargs) for perm in perms],
-                               dim=1)
+        perms = torch.tensor(list(permutations(range(n_src))), dtype=torch.long)
+        loss_set = torch.stack(
+            [loss_func(est_targets[:, perm], targets, **kwargs) for perm in perms], dim=1
+        )
         # Indexes and values of min losses for each batch element
-        min_loss, min_loss_idx = torch.min(loss_set, dim=1, keepdim=True)
-        return min_loss, min_loss_idx[:, 0]
+        min_loss, min_loss_idx = torch.min(loss_set, dim=1)
+        # Permutation indices for each batch.
+        batch_indices = torch.stack([perms[m] for m in min_loss_idx], dim=0)
+        return min_loss, batch_indices
 
+     @staticmethod
+    
     @staticmethod
     def best_part_mix_it(loss_func, est_targets, targets, **kwargs):
         """ Find best partition of the estimated sources that gives
@@ -385,13 +385,16 @@ class PITLossWrapper(nn.Module):
         return min_loss, ordered
 
     @staticmethod
-    def find_best_perm(pair_wise_losses, n_src, perm_reduce=None, **kwargs):
+    def find_best_perm(pair_wise_losses, perm_reduce=None, **kwargs):
         """Find the best permutation, given the pair-wise losses.
+
+        Dispatch between factorial method if number of sources is small (<3)
+        and hungarian method for more sources. If `perm_reduce` is not None,
+        the factorial method is always used.
 
         Args:
             pair_wise_losses (:class:`torch.Tensor`):
                 Tensor of shape [batch, n_src, n_src]. Pairwise losses.
-            n_src (int): Number of sources.
             perm_reduce (Callable): torch function to reduce permutation losses.
                 Defaults to None (equivalent to mean). Signature of the func
                 (pwl_set, **kwargs) : (B, n_src!, n_src) --> (B, n_src!)
@@ -403,63 +406,124 @@ class PITLossWrapper(nn.Module):
                 :class:`torch.Tensor`: The loss corresponding to the best
                 permutation of size (batch,).
 
-                :class:`torch.LongTensor`: The indexes of the best permutations.
+                :class:`torch.Tensor`: The indices of the best permutations.
+        """
+        n_src = pair_wise_losses.shape[-1]
+        if perm_reduce is not None or n_src <= 3:
+            min_loss, batch_indices = PITLossWrapper.find_best_perm_factorial(
+                pair_wise_losses, perm_reduce=perm_reduce, **kwargs
+            )
+        else:
+            min_loss, batch_indices = PITLossWrapper.find_best_perm_hungarian(pair_wise_losses)
+        return min_loss, batch_indices
+
+    @staticmethod
+    def reorder_source(source, batch_indices):
+        """Reorder sources according to the best permutation.
+
+        Args:
+            source (torch.Tensor): Tensor of shape [batch, n_src, time]
+            batch_indices (torch.Tensor): Tensor of shape [batch, n_src].
+                Contains optimal permutation indices for each batch.
+
+        Returns:
+            :class:`torch.Tensor`:
+                Reordered sources of shape [batch, n_src, time].
+        """
+        reordered_sources = torch.stack(
+            [torch.index_select(s, 0, b) for s, b in zip(source, batch_indices)]
+        )
+        return reordered_sources
+
+    @staticmethod
+    def find_best_perm_factorial(pair_wise_losses, perm_reduce=None, **kwargs):
+        """Find the best permutation given the pair-wise losses by looping
+        through all the permutations.
+
+        Args:
+            pair_wise_losses (:class:`torch.Tensor`):
+                Tensor of shape [batch, n_src, n_src]. Pairwise losses.
+            perm_reduce (Callable): torch function to reduce permutation losses.
+                Defaults to None (equivalent to mean). Signature of the func
+                (pwl_set, **kwargs) : (B, n_src!, n_src) --> (B, n_src!)
+            **kwargs: additional keyword argument that will be passed to the
+                permutation reduce function.
+
+        Returns:
+            tuple:
+                :class:`torch.Tensor`: The loss corresponding to the best
+                permutation of size (batch,).
+
+                :class:`torch.Tensor`: The indices of the best permutations.
 
         MIT Copyright (c) 2018 Kaituo XU.
         See `Original code
         <https://github.com/kaituoxu/Conv-TasNet/blob/master>`__ and `License
         <https://github.com/kaituoxu/Conv-TasNet/blob/master/LICENSE>`__.
         """
+        n_src = pair_wise_losses.shape[-1]
         # After transposition, dim 1 corresp. to sources and dim 2 to estimates
         pwl = pair_wise_losses.transpose(-1, -2)
-        perms = pwl.new_tensor(list(permutations(range(n_src))),
-                               dtype=torch.long)
+        perms = pwl.new_tensor(list(permutations(range(n_src))), dtype=torch.long)
         # Column permutation indices
         idx = torch.unsqueeze(perms, 2)
         # Loss mean of each permutation
         if perm_reduce is None:
             # one-hot, [n_src!, n_src, n_src]
             perms_one_hot = pwl.new_zeros((*perms.size(), n_src)).scatter_(2, idx, 1)
-            loss_set = torch.einsum('bij,pij->bp', [pwl, perms_one_hot])
+            loss_set = torch.einsum("bij,pij->bp", [pwl, perms_one_hot])
             loss_set /= n_src
         else:
-            batch = pwl.shape[0]
-            n_perm = idx.shape[0]
+            # batch = pwl.shape[0]; n_perm = idx.shape[0]
             # [batch, n_src!, n_src] : Pairwise losses for each permutation.
             pwl_set = pwl[:, torch.arange(n_src), idx.squeeze(-1)]
             # Apply reduce [batch, n_src!, n_src] --> [batch, n_src!]
             loss_set = perm_reduce(pwl_set, **kwargs)
         # Indexes and values of min losses for each batch element
-        min_loss_idx = torch.argmin(loss_set, dim=1)
-        min_loss, _ = torch.min(loss_set, dim=1, keepdim=True)
-        return min_loss, min_loss_idx
+        min_loss, min_loss_idx = torch.min(loss_set, dim=1)
+
+        # Permutation indices for each batch.
+        batch_indices = torch.stack([perms[m] for m in min_loss_idx], dim=0)
+        return min_loss, batch_indices
 
     @staticmethod
-    def reorder_source(source, n_src, min_loss_idx):
-        """ Reorder sources according to the best permutation.
+    def find_best_perm_hungarian(pair_wise_losses: torch.Tensor):
+        """Find the best permutation given the pair-wise losses, using the
+        Hungarian algorithm.
 
         Args:
-            source (torch.Tensor): Tensor of shape [batch, n_src, time]
-            n_src (int): Number of sources.
-            min_loss_idx (torch.LongTensor): Tensor of shape [batch],
-                each item is in [0, n_src!).
+            pair_wise_losses (:class:`torch.Tensor`):
+                Tensor of shape [batch, n_src, n_src]. Pairwise losses.
 
         Returns:
-            :class:`torch.Tensor`:
-                Reordered sources of shape [batch, n_src, time].
+            tuple:
+                :class:`torch.Tensor`: The loss corresponding to the best
+                permutation of size (batch,).
 
-        MIT Copyright (c) 2018 Kaituo XU.
-        See `Original code
-        <https://github.com/kaituoxu/Conv-TasNet/blob/master>`__ and `License
-        <https://github.com/kaituoxu/Conv-TasNet/blob/master/LICENSE>`__.
+                :class:`torch.Tensor`: The indices of the best permutations.
         """
-        perms = source.new_tensor(list(permutations(range(n_src))),
-                                  dtype=torch.long)
-        # Reorder estimate targets according the best permutation
-        min_loss_perm = torch.index_select(perms, dim=0, index=min_loss_idx)
-        # maybe use torch.gather()/index_select()/scatter() to impl this?
-        reordered_sources = torch.zeros_like(source)
-        for b in range(source.shape[0]):
-            for c in range(n_src):
-                reordered_sources[b, c] = source[b, min_loss_perm[b][c]]
-        return reordered_sources
+        # After transposition, dim 1 corresp. to sources and dim 2 to estimates
+        pwl = pair_wise_losses.transpose(-1, -2)
+        # Just bring the numbers to cpu(), not the graph
+        pwl_copy = pwl.detach().cpu()
+        # Loop over batch + row indices are always ordered for square matrices.
+        batch_indices = torch.tensor([linear_sum_assignment(pwl)[1] for pwl in pwl_copy]).to(
+            pwl.device
+        )
+        min_loss = torch.gather(pwl, 2, batch_indices[..., None]).mean([-1, -2])
+        return min_loss, batch_indices
+
+
+class PITReorder(PITLossWrapper):
+    """Permutation invariant reorderer. Only returns the reordered estimates.
+    See `:py:class:asteroid.losses.PITLossWrapper`."""
+
+    def forward(self, est_targets, targets, reduce_kwargs=None, **kwargs):
+        _, reordered = super().forward(
+            est_targets=est_targets,
+            targets=targets,
+            return_est=True,
+            reduce_kwargs=reduce_kwargs,
+            **kwargs,
+        )
+        return reordered

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -257,12 +257,12 @@ class PITLossWrapper(nn.Module):
         assert est_targets.shape[0] == targets.shape[0]
         assert est_targets.shape[2] == targets.shape[2]
 
-        # get L, N and M
-        L = targets.shape[1]        # number of mixtures 
-        N = est_targets.shape[1]    # number of estimated sources
-        if N % L != 0:
+        # get dimensions
+        n_mixtures = targets.shape[1]        # number of mixtures 
+        n_est = est_targets.shape[1]         # number of estimated sources
+        if n_est % n_mixtures != 0:
             raise ValueError('The mixtures are assumed to contain the same number of sources')
-        M = N // L                  # number of sources in each mixture
+        n_src = n_est // n_mixtures          # number of sources in each mixture
 
         # Generate all unique partitions of size k from a list lst of
         # length n, where l = n // k is the number of parts. The total
@@ -278,10 +278,10 @@ class PITLossWrapper(nn.Module):
                         yield [list(c), *r]
 
         # Generate all the possible partitions
-        parts = list(combs(range(N), M, L))     
+        parts = list(combs(range(n_est), n_src, n_mixtures))     
         for p, partition in enumerate(parts):
-            assert len(partition[0]) == M
-            assert len(partition) == L
+            assert len(partition[0]) == n_src
+            assert len(partition) == n_mixtures
         
             # sum the sources according to the given partition
             est_mixes = torch.stack([torch.sum(est_targets[:, indexes, :], axis=1) for indexes in partition], axis=1)
@@ -340,11 +340,11 @@ class PITLossWrapper(nn.Module):
         assert est_targets.shape[0] == targets.shape[0]
         assert est_targets.shape[2] == targets.shape[2]
 
-        # get L, N and M
-        L = targets.shape[1]        # number of mixtures 
-        N = est_targets.shape[1]    # number of estimated sources
+        # get dimensions
+        n_mixtures = targets.shape[1]        # number of mixtures 
+        n_est = est_targets.shape[1]         # number of estimated sources
 
-        if L != 2:
+        if n_mixtures != 2:
             raise ValueError('Works only with two mixtures')
 
         # Generate all unique partitions of any size from a list lst of
@@ -358,9 +358,9 @@ class PITLossWrapper(nn.Module):
             return all_combinations
 
         # Generate all the possible partitions
-        parts = all_combinations(range(N))    
+        parts = all_combinations(range(n_est))    
         for p, partition in enumerate(parts):
-            assert len(partition) == L
+            assert len(partition) == n_mixtures
         
             # sum the sources according to the given partition
             est_mixes = torch.stack([torch.sum(est_targets[:, indexes, :], axis=1) for indexes in partition], axis=1)

--- a/docs/source/package_reference/losses.rst
+++ b/docs/source/package_reference/losses.rst
@@ -11,7 +11,17 @@ Losses & Metrics
 Permutation invariant training (PIT) made easy
 ----------------------------------------------
 
+Asteroid supports regular Permutation Invariant Training (PIT), it's extension
+using Sinkhorn algorithm (SinkPIT) as well as Mixture Invariant Training (MixIT).
+
+
 .. automodule:: asteroid.losses.pit_wrapper
+   :members:
+
+.. automodule:: asteroid.losses.sinkpit_wrapper
+   :members:
+
+.. automodule:: asteroid.losses.mixit_wrapper
    :members:
 
 Available loss functions

--- a/tests/losses/mixit_wrapper_test.py
+++ b/tests/losses/mixit_wrapper_test.py
@@ -17,7 +17,7 @@ def test_mixitwrapper_as_pit_wrapper(batch_size, n_src, time):
     est_targets = torch.randn(batch_size, n_src, time)
 
     # mix_it base case: targets == mixtures / With and without return estimates
-    loss = MixITLossWrapper(good_batch_loss_func)
+    loss = MixITLossWrapper(good_batch_loss_func, generalized=False)
     loss(est_targets, targets)
     loss_value, reordered_est = loss(est_targets, targets, return_est=True)
     assert reordered_est.shape == est_targets.shape
@@ -33,14 +33,14 @@ def test_mixit_wrapper(batch_size, factor, n_mix, time):
     est_targets = torch.randn(batch_size, n_src, time)
 
     # mix_it / With and without return estimates
-    loss = MixITLossWrapper(good_batch_loss_func)
+    loss = MixITLossWrapper(good_batch_loss_func, generalized=False)
     loss(est_targets, mixtures)
     loss_value, reordered_mix = loss(est_targets, mixtures, return_est=True)
     assert reordered_mix.shape == mixtures.shape
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 8])
-@pytest.mark.parametrize("n_src", [2, 3, 4])
+@pytest.mark.parametrize("n_src", [2, 3, 4, 5])
 @pytest.mark.parametrize("n_mix", [2])
 @pytest.mark.parametrize("time", [16000])
 def test_mixit_gen_wrapper(batch_size, n_src, n_mix, time):
@@ -48,7 +48,7 @@ def test_mixit_gen_wrapper(batch_size, n_src, n_mix, time):
     est_targets = torch.randn(batch_size, n_src, time)
 
     # mix_it_gen / With and without return estimates. Works only with two mixtures
-    loss = MixITLossWrapper(good_batch_loss_func, generalized=True)
+    loss = MixITLossWrapper(good_batch_loss_func)
     loss(est_targets, mixtures)
     loss_value, reordered_est = loss(est_targets, mixtures, return_est=True)
     assert reordered_est.shape == mixtures.shape

--- a/tests/losses/mixit_wrapper_test.py
+++ b/tests/losses/mixit_wrapper_test.py
@@ -1,0 +1,49 @@
+import pytest
+import itertools
+import torch
+from torch.testing import assert_allclose
+
+from asteroid.losses import MixITLossWrapper, pairwise_mse
+
+
+def good_batch_loss_func(y_pred, y_true):
+    batch, *_ = y_true.shape
+    return torch.randn(batch)
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 8])
+@pytest.mark.parametrize("factor", [1, 2, 3])
+@pytest.mark.parametrize("n_mix", [2, 3])
+@pytest.mark.parametrize("time", [16000])
+def test_mixit_wrapper(batch_size, n_mix, time, factor):
+    mixtures = torch.randn(batch_size, n_mix, time)
+    n_src = n_mix * factor
+    targets = torch.randn(batch_size, n_src, time)
+    est_targets = torch.randn(batch_size, n_src, time)
+
+    # mix_it base case: targets == mixtures / With and without return estimates
+    loss = MixITLossWrapper(good_batch_loss_func, pit_from="mix_it")
+    loss(est_targets, targets)
+    loss_value, reordered_est = loss(est_targets, targets, return_est=True)
+    assert reordered_est.shape == est_targets.shape
+
+    # mix_it / With and without return estimates
+    loss = MixITLossWrapper(good_batch_loss_func, pit_from="mix_it")
+    loss(est_targets, mixtures)
+    loss_value, reordered_est = loss(est_targets, mixtures, return_est=True)
+    assert reordered_est.shape == mixtures.shape
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 8])
+@pytest.mark.parametrize("n_src", [2, 3, 4])
+@pytest.mark.parametrize("n_mix", [2])
+@pytest.mark.parametrize("time", [16000])
+def test_mixit_gen_wrapper(batch_size, n_src, n_mix, time):
+    mixtures = torch.randn(batch_size, n_mix, time)
+    est_targets = torch.randn(batch_size, n_src, time)
+
+    # mix_it_gen / With and without return estimates. Works only with two mixtures
+    loss = MixITLossWrapper(good_batch_loss_func, pit_from="mix_it_gen")
+    loss(est_targets, mixtures)
+    loss_value, reordered_est = loss(est_targets, mixtures, return_est=True)
+    assert reordered_est.shape == mixtures.shape

--- a/tests/losses/mixit_wrapper_test.py
+++ b/tests/losses/mixit_wrapper_test.py
@@ -1,9 +1,7 @@
 import pytest
-import itertools
 import torch
-from torch.testing import assert_allclose
 
-from asteroid.losses import MixITLossWrapper, pairwise_mse
+from asteroid.losses import MixITLossWrapper
 
 
 def good_batch_loss_func(y_pred, y_true):
@@ -12,26 +10,33 @@ def good_batch_loss_func(y_pred, y_true):
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 8])
-@pytest.mark.parametrize("factor", [1, 2, 3])
-@pytest.mark.parametrize("n_mix", [2, 3])
+@pytest.mark.parametrize("n_src", [2, 3, 4])
 @pytest.mark.parametrize("time", [16000])
-def test_mixit_wrapper(batch_size, n_mix, time, factor):
-    mixtures = torch.randn(batch_size, n_mix, time)
-    n_src = n_mix * factor
+def test_mixitwrapper_as_pit_wrapper(batch_size, n_src, time):
     targets = torch.randn(batch_size, n_src, time)
     est_targets = torch.randn(batch_size, n_src, time)
 
     # mix_it base case: targets == mixtures / With and without return estimates
-    loss = MixITLossWrapper(good_batch_loss_func, pit_from="mix_it")
+    loss = MixITLossWrapper(good_batch_loss_func)
     loss(est_targets, targets)
     loss_value, reordered_est = loss(est_targets, targets, return_est=True)
     assert reordered_est.shape == est_targets.shape
 
+
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+@pytest.mark.parametrize("factor", [1, 2, 3])
+@pytest.mark.parametrize("n_mix", [2, 3])
+@pytest.mark.parametrize("time", [16000])
+def test_mixit_wrapper(batch_size, factor, n_mix, time):
+    mixtures = torch.randn(batch_size, n_mix, time)
+    n_src = n_mix * factor
+    est_targets = torch.randn(batch_size, n_src, time)
+
     # mix_it / With and without return estimates
-    loss = MixITLossWrapper(good_batch_loss_func, pit_from="mix_it")
+    loss = MixITLossWrapper(good_batch_loss_func)
     loss(est_targets, mixtures)
-    loss_value, reordered_est = loss(est_targets, mixtures, return_est=True)
-    assert reordered_est.shape == mixtures.shape
+    loss_value, reordered_mix = loss(est_targets, mixtures, return_est=True)
+    assert reordered_mix.shape == mixtures.shape
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 8])
@@ -43,7 +48,7 @@ def test_mixit_gen_wrapper(batch_size, n_src, n_mix, time):
     est_targets = torch.randn(batch_size, n_src, time)
 
     # mix_it_gen / With and without return estimates. Works only with two mixtures
-    loss = MixITLossWrapper(good_batch_loss_func, pit_from="mix_it_gen")
+    loss = MixITLossWrapper(good_batch_loss_func, generalized=True)
     loss(est_targets, mixtures)
     loss_value, reordered_est = loss(est_targets, mixtures, return_est=True)
     assert reordered_est.shape == mixtures.shape

--- a/tests/losses/pit_wrapper_test.py
+++ b/tests/losses/pit_wrapper_test.py
@@ -51,8 +51,7 @@ def test_wrapper(batch_size, n_src, time):
     loss(est_targets, targets)
     loss_value, reordered_est = loss(est_targets, targets, return_est=True)
     assert reordered_est.shape == est_targets.shape
-
-
+    
 @pytest.mark.parametrize("batch_size", [1, 2, 8])
 @pytest.mark.parametrize("factor", [1, 2, 3])
 @pytest.mark.parametrize("n_mix", [2])
@@ -152,3 +151,19 @@ def test_permreduce_args():
     loss_func = PITLossWrapper(pairwise_mse, pit_from="pw_mtx", perm_reduce=reduce_func)
     weights = torch.softmax(torch.randn(10, n_src), dim=-1)
     loss_func(est_sources, sources, reduce_kwargs={"class_weights": weights})
+
+
+@pytest.mark.parametrize("n_src", [2, 4, 5, 6, 8])
+def test_best_perm_match(n_src):
+    pwl = torch.randn(2, n_src, n_src)
+
+    min_loss, min_idx = PITLossWrapper.find_best_perm_factorial(pwl)
+    min_loss_hun, min_idx_hun = PITLossWrapper.find_best_perm_hungarian(pwl)
+
+    assert_allclose(min_loss, min_loss_hun)
+    assert_allclose(min_idx, min_idx_hun)
+
+
+def test_raises_wrong_pit_from():
+    with pytest.raises(ValueError):
+        PITLossWrapper(lambda x: x, pit_from="unknown_mode")

--- a/tests/losses/pit_wrapper_test.py
+++ b/tests/losses/pit_wrapper_test.py
@@ -51,43 +51,6 @@ def test_wrapper(batch_size, n_src, time):
     loss(est_targets, targets)
     loss_value, reordered_est = loss(est_targets, targets, return_est=True)
     assert reordered_est.shape == est_targets.shape
-    
-@pytest.mark.parametrize("batch_size", [1, 2, 8])
-@pytest.mark.parametrize("factor", [1, 2, 3])
-@pytest.mark.parametrize("n_mix", [2])
-@pytest.mark.parametrize("time", [16000])
-def test_mixit_wrapper(batch_size, n_mix, time, factor):
-    mixtures = torch.randn(batch_size, n_mix, time)
-    n_src = n_mix * factor
-    targets = torch.randn(batch_size, n_src, time)
-    est_targets = torch.randn(batch_size, n_src, time)
-
-    # mix_it base case: targets == mixtures / With and without return estimates
-    loss = PITLossWrapper(good_batch_loss_func, pit_from="mix_it")
-    loss(est_targets, targets)
-    loss_value, reordered_est = loss(est_targets, targets, return_est=True)
-    assert reordered_est.shape == est_targets.shape
-
-    # mix_it / With and without return estimates
-    loss = PITLossWrapper(good_batch_loss_func, pit_from="mix_it")
-    loss(est_targets, mixtures)
-    loss_value, reordered_est = loss(est_targets, mixtures, return_est=True)
-    assert reordered_est.shape == mixtures.shape
-
-
-@pytest.mark.parametrize("batch_size", [1, 2, 8])
-@pytest.mark.parametrize("n_src", [2, 3, 4])
-@pytest.mark.parametrize("n_mix", [2])
-@pytest.mark.parametrize("time", [16000])
-def test_mixit_gen_wrapper(batch_size, n_src, n_mix, time):
-    mixtures = torch.randn(batch_size, n_mix, time)
-    est_targets = torch.randn(batch_size, n_src, time)
-
-    # mix_it_gen / With and without return estimates. Works only with two mixtures
-    loss = PITLossWrapper(good_batch_loss_func, pit_from="mix_it_gen")
-    loss(est_targets, mixtures)
-    loss_value, reordered_est = loss(est_targets, mixtures, return_est=True)
-    assert reordered_est.shape == mixtures.shape
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hi!

I implemented a mixture invariant training loss wrapper inspired by the paper "Unsupervised sound separation using mixtures of mixtures." arXiv preprint arXiv:2006.12701 (2020). 

Specifically, there are two new options for PITLossWrapper:
1. `mix_it`: Find the best partition of the estimated sources that gives the minimum loss for the MixIT training paradigm. Valid for any number of mixtures as soon as they contain the same number of sources.
2. `mix_it_gen`: Find the best partition of the estimated sources that gives the minimum loss for the MixIT training paradigm. Valid only for two mixtures, but those mixtures do not necessarily have to contain the same number of sources. It is allowed the case where one mixture is silent.

