### PR TITLE
BaseModel takes sample_rate argument

### DIFF
--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -32,8 +32,9 @@ class BaseModel(nn.Module):
 
     """
 
-    def __init__(self):
+    def __init__(self, sample_rate: float = 8000.0):
         super().__init__()
+        self.__sample_rate = sample_rate
 
     def forward(self, *args, **kwargs):
         raise NotImplementedError
@@ -41,7 +42,16 @@ class BaseModel(nn.Module):
     @property
     def sample_rate(self):
         """Operating sample rate of the model (float)."""
-        raise NotImplementedError
+        return self.__sample_rate
+
+    @sample_rate.setter
+    def sample_rate(self, new_sample_rate: float):
+        warnings.warn(
+            "Other sub-components of the model might have a `sample_rate` "
+            "attribute, be sure to modify them for consistency.",
+            UserWarning,
+        )
+        self.__sample_rate = new_sample_rate
 
     @torch.no_grad()
     def separate(self, wav, output_dir=None, force_overwrite=False, resample=False, **kwargs):

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -285,16 +285,12 @@ class BaseEncoderMaskerDecoder(BaseModel):
     """
 
     def __init__(self, encoder, masker, decoder, encoder_activation=None):
-        super().__init__()
+        super().__init__(sample_rate=getattr(self.encoder, "sample_rate", None))
         self.encoder = encoder
         self.masker = masker
         self.decoder = decoder
         self.encoder_activation = encoder_activation
         self.enc_activation = activations.get(encoder_activation or "linear")()
-
-    @property
-    def sample_rate(self):
-        return getattr(self.encoder, "sample_rate", None)
 
     def forward(self, wav):
         """Enc/Mask/Dec model forward

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -285,7 +285,7 @@ class BaseEncoderMaskerDecoder(BaseModel):
     """
 
     def __init__(self, encoder, masker, decoder, encoder_activation=None):
-        super().__init__(sample_rate=getattr(self.encoder, "sample_rate", None))
+        super().__init__(sample_rate=getattr(encoder, "sample_rate", None))
         self.encoder = encoder
         self.masker = masker
         self.decoder = decoder

--- a/tests/models/models_test.py
+++ b/tests/models/models_test.py
@@ -20,6 +20,12 @@ from asteroid.models import (
 from asteroid.models.base_models import BaseModel
 
 
+def test_set_sample_rate_raises_warning():
+    model = BaseModel(sample_rate=8000.0)
+    with pytest.warns(UserWarning):
+        model.sample_rate = 16000.0
+
+
 def test_convtasnet_sep():
     nnet = ConvTasNet(
         n_src=2,


### PR DESCRIPTION
Addresses #318

From what I understood, the main concern in passing `sample_rate` to `BaseModel` is that we duplicate reference to it, and users might change it without changing other part of the model that reference it. See [comment](https://github.com/mpariente/asteroid/issues/318#issuecomment-723481927). 

This is what I propose: 
Having `__sample_rate` with dunder means that `model.__sample_rate` cannot be accessed/changed directly. But it can be accessed from `model._BaseModel__sample_rate` which most users won't even know IMO. 
Instead, we provide a setter for the `sample_rate` property and warn the user that there might be some inconsistencies. 
WDYT? 


### Proof of concept
```python
In [1]: class Trial:
   ...:     def __init__(self, sample_rate):
   ...:         self.__sample_rate = sample_rate
   ...: 
   ...:     @property
   ...:     def sample_rate(self):
   ...:         return self.__sample_rate
   ...: 
   ...:     @sample_rate.setter
   ...:     def sample_rate(self, new_sample_rate):
   ...:         self.__sample_rate = new_sample_rate
   ...: 

In [2]: model = Trial(8000.0)

In [3]: model.__sample_rate
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-c29e6b91ff0f> in <module>
----> 1 model.__sample_rate

AttributeError: 'Trial' object has no attribute '__sample_rate'

In [4]: model._Trial__sample_rate
Out[4]: 8000.0

In [5]: model._Trial__sample_rate = 10

In [6]: model.sample_rate
Out[6]: 10

In [7]: model.sample_rate = 12

In [8]: model.sample_rate
Out[8]: 12

In [9]: model._Trial__sample_rate
Out[9]: 12

```

Obviously, the rest of the models need to account for the change, I just propose this design and will fix the rest when we agreed. 
