### PR TITLE
BaseModel shape reconstruction: Use shape instead of waveform

### DIFF
--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -6,7 +6,7 @@ import torch
 from torch import nn
 
 from ..masknn import activations
-from ..utils.torch_utils import pad_x_to_y, script_if_tracing, jitable_shape
+from ..utils.torch_utils import pad_x_to_shape, script_if_tracing, jitable_shape
 from ..utils.hub_utils import cached_download
 
 
@@ -312,7 +312,7 @@ class BaseEncoderMaskerDecoder(BaseModel):
         masked_tf_rep = self.apply_masks(tf_rep, est_masks)
         decoded = self.forward_decoder(masked_tf_rep)
 
-        reconstructed = pad_x_to_y(decoded, wav)
+        reconstructed = pad_x_to_shape(decoded, shape)
         return _shape_reconstructed(reconstructed, shape)
 
     def forward_encoder(self, wav):

--- a/asteroid/utils/torch_utils.py
+++ b/asteroid/utils/torch_utils.py
@@ -119,6 +119,61 @@ def pad_x_to_y(x: torch.Tensor, y: torch.Tensor, axis: int = -1) -> torch.Tensor
     return nn.functional.pad(x, [0, inp_len - output_len])
 
 
+@script_if_tracing
+def pad_x_to_shape(x: torch.Tensor, shape, axis: int = -1) -> torch.Tensor:
+    """Right-pad first argument to have same size as the given `shape`
+
+    Args:
+        x (torch.Tensor): Tensor to be padded.
+        shape (Union[torch.Tensor, Tuple]): Shape to pad `x` to
+        axis (int): Axis to pad on.
+
+    Returns:
+        torch.Tensor, `x` padded to match `shape`.
+    """
+    if axis != -1:
+        raise NotImplementedError
+    inp_len = int(shape[axis])
+    output_len = x.shape[axis]
+    return nn.functional.pad(x, [0, inp_len - output_len])
+
+
+@script_if_tracing
+def trim_x_to_shape(x: torch.Tensor, shape, axis: int = -1) -> torch.Tensor:
+    """Right-trim first argument to have same size as the given `shape`
+
+    Args:
+        x (torch.Tensor): Tensor to be trimmed.
+        shape (Union[torch.Tensor, Tuple]): Shape to trim `x` to
+        axis (int): Axis to trim on.
+
+    Returns:
+        torch.Tensor, `x` trimmed to match `shape`.
+    """
+    if axis != -1:
+        raise NotImplementedError
+    inp_len = int(shape[axis])
+    return x[..., :inp_len]
+
+
+@script_if_tracing
+def pad_or_trim_x_to_shape(x: torch.Tensor, shape, axis: int = -1) -> torch.Tensor:
+    """Right-pad or right-trim first argument to have same size as the given `shape`
+
+    Args:
+        x (torch.Tensor): Tensor to be padded/trimmed.
+        shape (Union[torch.Tensor, Tuple]): Shape to pad/trim `x` to
+        axis (int): Axis to pad/trim on.
+
+    Returns:
+        torch.Tensor, `x` padded/trimmed to match `shape`.
+    """
+    if x.shape[axis] < shape[axis]:
+        return pad_x_to_shape(x, shape, axis=axis)
+    else:
+        return trim_x_to_shape(x, shape, axis=axis)
+
+
 def load_state_dict_in(state_dict, model):
     """Strictly loads state_dict in model, or the next submodel.
         Useful to load standalone model after training it with System.


### PR DESCRIPTION
Does this work? I was wondering this just now when working on the trimming/padding stuff in #276. It could be a way to save some GPU memory.