### PR TITLE
Add asteroid-versions script to print installed versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,21 @@ Steps to reproduce the behavior (code sample and stack trace):
 
 ### Environment
 
- - Asteroid Version or commit tag (`git log --pretty=format:'%h' -n 1`)
- - PyTorch Version (e.g., 1.6.0)
- - PyTorchLightning Version
- - Additional info (environment, custom script, etc..)
+#### Package versions
+
+Run `asteroid-versions` and paste the output here:
+
+```
+Paste here
+```
+
+Alternatively, if you cannot install Asteroid or have an old version that doesn't have the `asteroid-versions` script,
+please output the output of:
+
+```
+pip freeze | egrep -i 'pytorch|torch|asteroid'
+```
+
+#### Additional info
+
+Additional info (environment, custom script, etc...)

--- a/.github/ISSUE_TEMPLATE/how-to-question.md
+++ b/.github/ISSUE_TEMPLATE/how-to-question.md
@@ -15,10 +15,34 @@ assignees: ''
 
 <!-- If you still can't find what you need: -->
 
-#### What is your question?
+### What is your question?
 
 #### Code
 
 <!-- Please paste a code snippet if your question requires it! -->
 
 #### What have you tried?
+
+### Environment
+
+If the question is about a problem with using Asteroid or any of the code, please include
+your environment info:
+
+#### Package versions
+
+Run `asteroid-versions` and paste the output here:
+
+```
+Paste here
+```
+
+Alternatively, if you cannot install Asteroid or have an old version that doesn't have the `asteroid-versions` script,
+please output the output of:
+
+```
+pip freeze | egrep -i 'pytorch|torch|asteroid'
+```
+
+#### Additional info
+
+Additional info (environment, custom script, etc...)

--- a/asteroid/scripts/asteroid_versions.py
+++ b/asteroid/scripts/asteroid_versions.py
@@ -1,0 +1,55 @@
+import sys
+import pathlib
+import subprocess
+import torch
+import pytorch_lightning as pl
+import asteroid
+
+
+def print_versions():
+    """CLI function to get info about the Asteroid and dependency versions."""
+    for k, v in asteroid_env().items():
+        print(f"{k:20s}{v}")
+
+
+def asteroid_env():
+    return {
+        "Asteroid": asteroid_version(),
+        "PyTorch": pytorch_version(),
+        "PyTorch-Lightning": pytorch_lightning_version(),
+    }
+
+
+def pytorch_version():
+    return torch.__version__
+
+
+def pytorch_lightning_version():
+    return pl.__version__
+
+
+def asteroid_version():
+    asteroid_root = pathlib.Path(__file__).parent.parent.parent
+    if asteroid_root.joinpath(".git").exists():
+        return f"{asteroid.__version__}, Git checkout {get_git_version(asteroid_root)}"
+    else:
+        return asteroid.__version__
+
+
+def get_git_version(root):
+    def _git(*cmd):
+        return subprocess.check_output(["git", *cmd], cwd=root).strip().decode("ascii", "ignore")
+
+    try:
+        commit = _git("rev-parse", "HEAD")
+        branch = _git("rev-parse", "--symbolic-full-name", "--abbrev-ref", "HEAD")
+        dirty = _git("status", "--porcelain")
+    except Exception as err:
+        print(f"Failed to get Git checkout info: {err}", file=sys.stderr)
+        return ""
+    s = commit[:12]
+    if branch:
+        s += f" ({branch})"
+    if dirty:
+        s += f", dirty tree"
+    return s

--- a/asteroid/scripts/asteroid_versions.py
+++ b/asteroid/scripts/asteroid_versions.py
@@ -8,11 +8,11 @@ import asteroid
 
 def print_versions():
     """CLI function to get info about the Asteroid and dependency versions."""
-    for k, v in asteroid_env().items():
+    for k, v in asteroid_versions().items():
         print(f"{k:20s}{v}")
 
 
-def asteroid_env():
+def asteroid_versions():
     return {
         "Asteroid": asteroid_version(),
         "PyTorch": pytorch_version(),

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
             "asteroid-upload=asteroid.scripts.asteroid_cli:upload",
             "asteroid-infer=asteroid.scripts.asteroid_cli:infer",
             "asteroid-register-sr=asteroid.scripts.asteroid_cli:register_sample_rate",
+            "asteroid-versions=asteroid.scripts.asteroid_versions:print_versions",
         ],
     },
     packages=find_packages(),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+from asteroid.scripts import asteroid_versions
+
+
+def test_asteroid_versions():
+    versions = asteroid_versions.asteroid_versions()
+    assert "Asteroid" in versions
+    assert "PyTorch" in versions
+    assert "PyTorch-Lightning" in versions
+
+
+def test_print_versions():
+    asteroid_versions.print_versions()
+
+
+def test_asteroid_versions_without_git(monkeypatch):
+    monkeypatch.setenv("PATH", "")
+    asteroid_versions.asteroid_versions()


### PR DESCRIPTION
We could use this as for the issue templates.

```
$ asteroid-versions
Asteroid            0.4.0rc0, Git checkout f7938f3413bb (asteroid-env)
PyTorch             1.7.0+cpu
PyTorch-Lightning   0.9.0
```