### PR TITLE
Doc fixes

### DIFF
--- a/asteroid/complex_nn.py
+++ b/asteroid/complex_nn.py
@@ -165,7 +165,7 @@ class BoundComplexMask(nn.Module):
 def bound_complex_mask(mask: ComplexTensor, bound_type="tanh"):
     r"""Bound a complex mask, as proposed in [1], section 3.2.
 
-    Valid bound types, for a complex mask $M = |M| ⋅ e^{i φ(M)}$:
+    Valid bound types, for a complex mask :math:`M = |M| ⋅ e^{i φ(M)}`:
 
     - Unbounded ("UBD"): :math:`M_{\mathrm{UBD}} = M`
     - Sigmoid ("BDSS"): :math:`M_{\mathrm{BDSS}} = σ(|M|) e^{i σ(φ(M))}`
@@ -177,7 +177,7 @@ def bound_complex_mask(mask: ComplexTensor, bound_type="tanh"):
 
     References
         [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
-          Hyeong-Seok Choi et al. https://arxiv.org/abs/1903.03107
+        Hyeong-Seok Choi et al. https://arxiv.org/abs/1903.03107
     """
     if bound_type in {"BDSS", "sigmoid"}:
         return on_reim(torch.sigmoid)(mask)

--- a/asteroid/complex_nn.py
+++ b/asteroid/complex_nn.py
@@ -176,7 +176,7 @@ def bound_complex_mask(mask: ComplexTensor, bound_type="tanh"):
             "tanh"/"bdt" (default), "sigmoid"/"bdss" or None/"bdt".
 
     References
-        - [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
+        [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
           Hyeong-Seok Choi et al. https://arxiv.org/abs/1903.03107
     """
     if bound_type in {"BDSS", "sigmoid"}:

--- a/asteroid/data/avspeech_dataset.py
+++ b/asteroid/data/avspeech_dataset.py
@@ -120,8 +120,8 @@ class AVSpeechDataset(data.Dataset):
         n_src (int): number of sources.
 
     References
-        - [1]: "Looking to Listen at the Cocktail Party: A Speaker-Independent Audio-Visual
-          Model for Speech Separation" Ephrat et. al https://arxiv.org/abs/1804.03619
+        "Looking to Listen at the Cocktail Party: A Speaker-Independent Audio-Visual
+        Model for Speech Separation" Ephrat et. al https://arxiv.org/abs/1804.03619
     """
 
     dataset_name = "AVSpeech"

--- a/asteroid/data/avspeech_dataset.py
+++ b/asteroid/data/avspeech_dataset.py
@@ -120,7 +120,7 @@ class AVSpeechDataset(data.Dataset):
         n_src (int): number of sources.
 
     References
-        "Looking to Listen at the Cocktail Party: A Speaker-Independent Audio-Visual
+        [1] "Looking to Listen at the Cocktail Party: A Speaker-Independent Audio-Visual
         Model for Speech Separation" Ephrat et. al https://arxiv.org/abs/1804.03619
     """
 

--- a/asteroid/data/dampvsep_dataset.py
+++ b/asteroid/data/dampvsep_dataset.py
@@ -18,8 +18,10 @@ class DAMPVSEPSinglesDataset(torch.utils.data.Dataset):
     Args:
         root_path (str): Root path to DAMP-VSEP dataset.
         task (str): one of ``'enh_vocal'``,``'separation'``.
+
             * ``'enh_vocal'`` for vocal enhanced.
             * ``'separation'`` for vocal and background separation.
+
         split (str):  one of ``'train_english'``, ``'train_singles'``,
             ``'valid'`` and ``'test'``.
             Default to ``'train_singles'``.
@@ -32,21 +34,25 @@ class DAMPVSEPSinglesDataset(torch.utils.data.Dataset):
         segment (float, optional): Duration of segments in seconds,
             Defaults to ``None`` which loads the full-length audio tracks.
         norm (Str, optional): Type of normalisation to use. Default to ``None``
+
             * ``'song_level'`` use mixture mean and std.
             * ```None``` no normalisation
+
         source_augmentations (Callable, optional): Augmentations applied to the sources (only).
             Default to ``None``.
         mixture (str, optional): Whether to use the original mixture with non-linear effects
             or remix sources. Default to original.
+
             * ``'remix'`` for use addition to remix the sources.
             * ``'original'`` for use the original mixture.
 
     .. note:: There are 2 train set available:
-        1- train_english: Uses all English spoken song.
-            Duets are converted into 2 singles.
-            Totalling 9243 performances and 77Hrs.
-        2- train_singles: Uses all singles performances, discarding all duets.
-            Totalling 20660 performances and 149 hrs.
+
+        * train_english: Uses all English spoken song. Duets are converted into 2 singles.
+          Totalling 9243 performances and 77Hrs.
+        * train_singles: Uses all singles performances, discarding all duets.
+          Totalling 20660 performances and 149 hrs.
+
     """
 
     dataset_name = "DAMP-VSEP"

--- a/asteroid/data/dns_dataset.py
+++ b/asteroid/data/dns_dataset.py
@@ -12,7 +12,7 @@ class DNSDataset(data.Dataset):
         json_dir (str): path to the JSON directory (from the recipe).
 
     References
-        - "The INTERSPEECH 2020 Deep Noise Suppression Challenge: Datasets,
+        "The INTERSPEECH 2020 Deep Noise Suppression Challenge: Datasets,
         Subjective Testing Framework, and Challenge Results", Reddy et al. 2020.
     """
 

--- a/asteroid/data/fuss_dataset.py
+++ b/asteroid/data/fuss_dataset.py
@@ -6,7 +6,7 @@ import soundfile as sf
 
 
 class FUSSDataset(Dataset):
-    """Dataset class for FUSS[1] tasks.
+    """Dataset class for FUSS [1] tasks.
 
     Args:
         file_list_path (str): Path to the txt (csv) file created at stage 2
@@ -15,7 +15,7 @@ class FUSSDataset(Dataset):
             and sources (useful for SIR, SAR computation). Default: False.
 
     References
-        - [1] Scott Wisdom et al. "What's All the FUSS About Free Universal
+        [1] Scott Wisdom et al. "What's All the FUSS About Free Universal
         Sound Separation Data?", 2020, in preparation.
     """
 

--- a/asteroid/data/kinect_wsj.py
+++ b/asteroid/data/kinect_wsj.py
@@ -41,7 +41,7 @@ class KinectWsjMixDataset(Wsj0mixDataset):
         n_src (int, optional): Number of sources in the training targets.
 
     References
-        - "Analyzing the impact of speaker localization errors on speech separation
+        "Analyzing the impact of speaker localization errors on speech separation
         for automatic speech recognition", Sunit Sivasankaran et al. 2020.
     """
 

--- a/asteroid/data/librimix_dataset.py
+++ b/asteroid/data/librimix_dataset.py
@@ -15,24 +15,24 @@ MINI_URL = "https://zenodo.org/record/3871592/files/MiniLibriMix.zip?download=1"
 
 
 class LibriMix(Dataset):
-    """Dataset class for Librimix source separation tasks.
+    """Dataset class for LibriMix source separation tasks.
 
     Args:
-        csv_dir (str): The path to the metatdata file
+        csv_dir (str): The path to the metadata file.
         task (str): One of ``'enh_single'``, ``'enh_both'``, ``'sep_clean'`` or
-            ``'sep_noisy'``.
+            ``'sep_noisy'`` :
 
             * ``'enh_single'`` for single speaker speech enhancement.
             * ``'enh_both'`` for multi speaker speech enhancement.
             * ``'sep_clean'`` for two-speaker clean source separation.
             * ``'sep_noisy'`` for two-speaker noisy source separation.
 
-        sample_rate (int) : The sample rate of the sources and mixtures
-        n_src (int) : The number of sources in the mixture
-        segment (int) : The desired sources and mixtures length in s
+        sample_rate (int) : The sample rate of the sources and mixtures.
+        n_src (int) : The number of sources in the mixture.
+        segment (int) : The desired sources and mixtures length in s.
 
     References
-        - [1] "LibriMix: An Open-Source Dataset for Generalizable Speech Separation",
+        [1] "LibriMix: An Open-Source Dataset for Generalizable Speech Separation",
         Cosentino et al. 2020.
     """
 
@@ -122,11 +122,11 @@ class LibriMix(Dataset):
                 instantiate the DatalLoader.
             **kwargs: keyword arguments to pass the `LibriMix`, see `__init__`.
                 The kwargs will be fed to both the training set and validation
-                set
+                set.
 
         Returns:
             train_loader, val_loader: training and validation DataLoader out of
-                `LibriMix` Dataset.
+            `LibriMix` Dataset.
 
         Examples
             >>> from asteroid.data import LibriMix
@@ -152,7 +152,7 @@ class LibriMix(Dataset):
 
         Returns:
             train_set, val_set: training and validation instances of
-                `LibriMix` (data.Dataset).
+            `LibriMix` (data.Dataset).
 
         Examples
             >>> from asteroid.data import LibriMix

--- a/asteroid/data/musdb18_dataset.py
+++ b/asteroid/data/musdb18_dataset.py
@@ -86,7 +86,7 @@ class MUSDB18Dataset(torch.utils.data.Dataset):
         tracks (:obj:`list` of :obj:`Dict`): List of track metadata
 
     References
-        - "The 2018 Signal Separation Evaluation Campaign" Stoter et al. 2018.
+        "The 2018 Signal Separation Evaluation Campaign" Stoter et al. 2018.
     """
 
     dataset_name = "MUSDB18"

--- a/asteroid/data/sms_wsj_dataset.py
+++ b/asteroid/data/sms_wsj_dataset.py
@@ -60,8 +60,8 @@ class SmsWsjDataset(data.Dataset):
             normalized with the standard deviation of the mixture.
 
     References
-        - "SMS-WSJ: Database, performance measures, and baseline recipe for
-          multi-channel source separation and recognition", Drude et al. 2019
+        "SMS-WSJ: Database, performance measures, and baseline recipe for
+        multi-channel source separation and recognition", Drude et al. 2019
     """
 
     dataset_name = "SMS_WSJ"

--- a/asteroid/data/wham_dataset.py
+++ b/asteroid/data/wham_dataset.py
@@ -56,7 +56,7 @@ class WhamDataset(data.Dataset):
             normalized with the standard deviation of the mixture.
 
     References
-        - "WHAM!: Extending Speech Separation to Noisy Environments",
+        "WHAM!: Extending Speech Separation to Noisy Environments",
         Wichern et al. 2019
     """
 

--- a/asteroid/data/whamr_dataset.py
+++ b/asteroid/data/whamr_dataset.py
@@ -73,8 +73,7 @@ class WhamRDataset(data.Dataset):
             separation tasks.
 
     References
-        "WHAMR!: Noisy and Reverberant Single-Channel Speech Separation",
-         Maciejewski et al. 2020
+        "WHAMR!: Noisy and Reverberant Single-Channel Speech Separation", Maciejewski et al. 2020
     """
 
     dataset_name = "WHAMR"

--- a/asteroid/data/whamr_dataset.py
+++ b/asteroid/data/whamr_dataset.py
@@ -73,8 +73,8 @@ class WhamRDataset(data.Dataset):
             separation tasks.
 
     References
-        - "WHAMR!: Noisy and Reverberant Single-Channel Speech Separation",
-          Maciejewski et al. 2020
+        "WHAMR!: Noisy and Reverberant Single-Channel Speech Separation",
+         Maciejewski et al. 2020
     """
 
     dataset_name = "WHAMR"

--- a/asteroid/data/wsj0_mix.py
+++ b/asteroid/data/wsj0_mix.py
@@ -39,8 +39,8 @@ class Wsj0mixDataset(data.Dataset):
         n_src (int, optional): Number of sources in the training targets.
 
     References
-        - "Deep clustering: Discriminative embeddings for segmentation and
-          separation", Hershey et al. 2015.
+        "Deep clustering: Discriminative embeddings for segmentation and
+        separation", Hershey et al. 2015.
     """
 
     dataset_name = "wsj0-mix"

--- a/asteroid/dsp/consistency.py
+++ b/asteroid/dsp/consistency.py
@@ -10,10 +10,9 @@ def mixture_consistency(
 ) -> torch.Tensor:
     """Applies mixture consistency to a tensor of estimated sources.
 
-    Args
+    Args:
         mixture (torch.Tensor): Mixture waveform or TF representation.
-        est_sources (torch.Tensor): Estimated sources waveforms or TF
-            representations.
+        est_sources (torch.Tensor): Estimated sources waveforms or TF representations.
         src_weights (torch.Tensor): Consistency weight for each source.
             Shape needs to be broadcastable to `est_source`.
             We make sure that the weights sum up to 1 along dim `dim`.
@@ -23,11 +22,6 @@ def mixture_consistency(
     Returns
         torch.Tensor with same shape as `est_sources`, after applying mixture
         consistency.
-
-    Notes
-        This method can be used only in 'complete' separation tasks, otherwise
-        the residual error will contain unwanted sources. For example, this
-        won't work with the task `sep_noisy` from WHAM.
 
     Examples
         >>> # Works on waveforms
@@ -39,10 +33,14 @@ def mixture_consistency(
         >>> est_sources = torch.randn(10, 2, 514, 400)
         >>> new_est_sources = mixture_consistency(mix, est_sources, dim=1)
 
+    .. note::
+        This method can be used only in 'complete' separation tasks, otherwise
+        the residual error will contain unwanted sources. For example, this
+        won't work with the task `"sep_noisy"` from WHAM.
+
     References
-        - Scott Wisdom, John R Hershey, Kevin Wilson, Jeremy Thorpe, Michael
-        Chinen, Brian Patton, and Rif A Saurous. "Differentiable consistency
-        constraints for improved deep speech enhancement", ICASSP 2019.
+        Scott Wisdom et al. "Differentiable consistency constraints for improved
+        deep speech enhancement", ICASSP 2019.
     """
     # If the source weights are not specified, the weights are the relative
     # power of each source to the sum. w_i = P_i / (P_all), P for power.

--- a/asteroid/dsp/overlap_add.py
+++ b/asteroid/dsp/overlap_add.py
@@ -175,9 +175,6 @@ def _reorder_sources(
                                     both current and previous.
         hop_size (:class:`int`): hop_size between current and previous tensors.
 
-    Returns:
-        current:
-
     """
     batch, frames = current.size()
     current = current.reshape(-1, n_src, frames)
@@ -201,15 +198,16 @@ def _reorder_sources(
 
 
 class DualPathProcessing(nn.Module):
-    """Perform Dual-Path processing via overlap-add as in DPRNN [1].
+    """
+    Perform Dual-Path processing via overlap-add as in DPRNN [1].
 
-     Args:
+    Args:
         chunk_size (int): Size of segmenting window.
         hop_size (int): segmentation hop size.
 
     References
-        - [1] "Dual-path RNN: efficient long sequence modeling for time-domain
-        single-channel speech separation", Yi Luo, Zhuo Chen and Takuya Yoshioka.
+        [1] Yi Luo, Zhuo Chen and Takuya Yoshioka. "Dual-path RNN: efficient
+        long sequence modeling for time-domain single-channel speech separation"
         https://arxiv.org/abs/1910.06379
     """
 
@@ -220,16 +218,16 @@ class DualPathProcessing(nn.Module):
         self.n_orig_frames = None
 
     def unfold(self, x):
-        """Unfold the feature tensor from
-
-        (batch, channels, time) to (batch, channels, chunk_size, n_chunks).
+        r"""
+        Unfold the feature tensor from $(batch, channels, time)$ to
+        $(batch, channels, chunksize, nchunks)$.
 
         Args:
-            x: (:class:`torch.Tensor`): feature tensor of shape (batch, channels, time).
+            x (:class:`torch.Tensor`): feature tensor of shape $(batch, channels, time)$.
 
         Returns:
-            x: (:class:`torch.Tensor`): spliced feature tensor of shape
-                (batch, channels, chunk_size, n_chunks).
+            :class:`torch.Tensor`: spliced feature tensor of shape
+            $(batch, channels, chunksize, nchunks)$.
 
         """
         # x is (batch, chan, frames)
@@ -248,22 +246,22 @@ class DualPathProcessing(nn.Module):
         )  # (batch, chan, chunk_size, n_chunks)
 
     def fold(self, x, output_size=None):
-        """Folds back the spliced feature tensor.
-
-        Input shape (batch, channels, chunk_size, n_chunks) to original shape
-        (batch, channels, time) using overlap-add.
+        r"""
+        Folds back the spliced feature tensor.
+        Input shape $(batch, channels, chunksize, nchunks)$ to original shape
+        $(batch, channels, time)$ using overlap-add.
 
         Args:
-            x: (:class:`torch.Tensor`): spliced feature tensor of shape
-                (batch, channels, chunk_size, n_chunks).
-            output_size: (int, optional): sequence length of original feature tensor.
-                If None, the original length cached by the previous call of `unfold`
-                will be used.
+            x (:class:`torch.Tensor`): spliced feature tensor of shape
+                $(batch, channels, chunksize, nchunks)$.
+            output_size (int, optional): sequence length of original feature tensor.
+                If None, the original length cached by the previous call of
+                :func:`~overlap_add.DualPathProcessing.unfold` will be used.
 
         Returns:
-            x: (:class:`torch.Tensor`):  feature tensor of shape (batch, channels, time).
+            :class:`torch.Tensor`:  feature tensor of shape $(batch, channels, time)$.
 
-        .. note:: `fold` caches the original length of the pr
+        .. note:: `fold` caches the original length of the input.
 
         """
         output_size = output_size if output_size is not None else self.n_orig_frames
@@ -285,7 +283,7 @@ class DualPathProcessing(nn.Module):
 
     @staticmethod
     def intra_process(x, module):
-        """Performs intra-chunk processing.
+        r"""Performs intra-chunk processing.
 
         Args:
             x (:class:`torch.Tensor`): spliced feature tensor of shape
@@ -293,13 +291,12 @@ class DualPathProcessing(nn.Module):
             module (:class:`torch.nn.Module`): module one wish to apply to each chunk
                 of the spliced feature tensor.
 
-
         Returns:
-            x (:class:`torch.Tensor`): processed spliced feature tensor of shape
-                (batch, channels, chunk_size, n_chunks).
+            :class:`torch.Tensor`: processed spliced feature tensor of shape
+            $(batch, channels, chunksize, nchunks)$.
 
         .. note:: the module should have the channel first convention and accept
-            a 3D tensor of shape (batch, channels, time).
+            a 3D tensor of shape $(batch, channels, time)$.
         """
 
         # x is (batch, channels, chunk_size, n_chunks)
@@ -312,21 +309,21 @@ class DualPathProcessing(nn.Module):
 
     @staticmethod
     def inter_process(x, module):
-        """Performs inter-chunk processing.
+        r"""Performs inter-chunk processing.
 
         Args:
             x (:class:`torch.Tensor`): spliced feature tensor of shape
-                (batch, channels, chunk_size, n_chunks).
+                $(batch, channels, chunksize, nchunks)$.
             module (:class:`torch.nn.Module`): module one wish to apply between
                 each chunk of the spliced feature tensor.
 
 
         Returns:
             x (:class:`torch.Tensor`): processed spliced feature tensor of shape
-                (batch, channels, chunk_size, n_chunks).
+            $(batch, channels, chunksize, nchunks)$.
 
         .. note:: the module should have the channel first convention and accept
-            a 3D tensor of shape (batch, channels, time).
+            a 3D tensor of shape $(batch, channels, time)$.
         """
 
         batch, channels, chunk_size, n_chunks = x.size()

--- a/asteroid/dsp/overlap_add.py
+++ b/asteroid/dsp/overlap_add.py
@@ -256,7 +256,7 @@ class DualPathProcessing(nn.Module):
                 $(batch, channels, chunksize, nchunks)$.
             output_size (int, optional): sequence length of original feature tensor.
                 If None, the original length cached by the previous call of
-                :func:`~overlap_add.DualPathProcessing.unfold` will be used.
+                :meth:`unfold` will be used.
 
         Returns:
             :class:`torch.Tensor`:  feature tensor of shape $(batch, channels, time)$.

--- a/asteroid/dsp/vad.py
+++ b/asteroid/dsp/vad.py
@@ -16,7 +16,7 @@ def ebased_vad(mag_spec, th_db: int = 40):
             silent.
 
     Returns:
-        torch.BoolTensor, the VAD mask.
+        :class:`torch.BoolTensor`, the VAD mask.
 
 
     Examples

--- a/asteroid/engine/schedulers.py
+++ b/asteroid/engine/schedulers.py
@@ -151,6 +151,7 @@ class DPTNetScheduler(BaseScheduler):
             )
         return lr
 
+
 def sinkpit_default_beta_schedule(epoch):
     return min([1.02 ** epoch, 10])
 
@@ -185,8 +186,8 @@ class SinkPITBetaScheduler(pl.callbacks.Callback):
         epoch = pl_module.current_epoch
         # step = pl_module.global_step
         beta = self.cooling_schedule(epoch)
-        pl_module.loss_func.beta = beta      
-        
-        
+        pl_module.loss_func.beta = beta
+
+
 # Backward compat
 _BaseScheduler = BaseScheduler

--- a/asteroid/engine/system.py
+++ b/asteroid/engine/system.py
@@ -21,15 +21,16 @@ class System(pl.LightningModule):
         val_loader (torch.utils.data.DataLoader): Validation dataloader.
         scheduler (torch.optim.lr_scheduler._LRScheduler): Instance, or list
             of learning rate schedulers. Also supports dict or list of dict as
-            `{"interval": "step", "scheduler": sched}` where `interval=="step"`
-            for step-wise schedulers and `interval=="epoch"` for classical ones.
+            ``{"interval": "step", "scheduler": sched}`` where ``interval=="step"``
+            for step-wise schedulers and ``interval=="epoch"`` for classical ones.
         config: Anything to be saved with the checkpoints during training.
             The config dictionary to re-instantiate the run for example.
-    .. note:: By default, `training_step` (used by `pytorch-lightning` in the
-        training loop) and `validation_step` (used for the validation loop)
-        share `common_step`. If you want different behavior for the training
-        loop and the validation loop, overwrite both `training_step` and
-        `validation_step` instead.
+
+    .. note:: By default, ``training_step`` (used by ``pytorch-lightning`` in the
+        training loop) and ``validation_step`` (used for the validation loop)
+        share ``common_step``. If you want different behavior for the training
+        loop and the validation loop, overwrite both ``training_step`` and
+        ``validation_step`` instead.
     """
 
     def __init__(
@@ -83,11 +84,12 @@ class System(pl.LightningModule):
         Returns:
             :class:`torch.Tensor` : The loss value on this batch.
 
-        .. note:: This is typically the method to overwrite when subclassing
-            `System`. If the training and validation steps are somehow
-            different (except for loss.backward() and optimzer.step()),
-            the argument `train` can be used to switch behavior.
-            Otherwise, `training_step` and `validation_step` can be overwriten.
+        .. note::
+            This is typically the method to overwrite when subclassing
+            ``System``. If the training and validation steps are somehow
+            different (except for ``loss.backward()`` and ``optimzer.step()``),
+            the argument ``train`` can be used to switch behavior.
+            Otherwise, ``training_step`` and ``validation_step`` can be overwriten.
         """
         inputs, targets = batch
         est_targets = self(inputs)
@@ -176,37 +178,39 @@ class System(pl.LightningModule):
         return [self.optimizer], epoch_schedulers
 
     def train_dataloader(self):
+        """Training dataloader"""
         return self.train_loader
 
     def val_dataloader(self):
+        """Validation dataloader"""
         return self.val_loader
 
     def on_save_checkpoint(self, checkpoint):
-        """ Overwrite if you want to save more things in the checkpoint."""
+        """Overwrite if you want to save more things in the checkpoint."""
         checkpoint["training_config"] = self.config
         return checkpoint
 
     def on_batch_start(self, batch):
-        """ Overwrite if needed. Called by pytorch-lightning"""
+        """Overwrite if needed. Called by pytorch-lightning"""
         pass
 
     def on_batch_end(self):
-        """ Overwrite if needed. Called by pytorch-lightning"""
+        """Overwrite if needed. Called by pytorch-lightning"""
         pass
 
     def on_epoch_start(self):
-        """ Overwrite if needed. Called by pytorch-lightning"""
+        """Overwrite if needed. Called by pytorch-lightning"""
         pass
 
     def on_epoch_end(self):
-        """ Overwrite if needed. Called by pytorch-lightning"""
+        """Overwrite if needed. Called by pytorch-lightning"""
         pass
 
     @staticmethod
     def config_to_hparams(dic):
         """Sanitizes the config dict to be handled correctly by torch
-        SummaryWriter. It flatten the config dict, converts `None` to
-         ``'None'`` and any list and tuple into torch.Tensors.
+        SummaryWriter. It flatten the config dict, converts ``None`` to
+        ``"None"`` and any list and tuple into torch.Tensors.
 
         Args:
             dic (dict): Dictionary to be transformed.

--- a/asteroid/losses/cluster.py
+++ b/asteroid/losses/cluster.py
@@ -2,13 +2,13 @@ import torch
 
 
 def deep_clustering_loss(embedding, tgt_index, binary_mask=None):
-    """Compute the deep clustering loss defined in [1].
+    r"""Compute the deep clustering loss defined in [1].
 
     Args:
         embedding (torch.Tensor): Estimated embeddings.
-            Expected shape  (batch, frequency x frame, embedding_dim)
+            Expected shape  :math:`(batch, frequency * frame, embedding\_dim)`.
         tgt_index (torch.Tensor): Dominating source index in each TF bin.
-            Expected shape: [batch, frequency, frame]
+            Expected shape: :math:`(batch, frequency, frame)`.
         binary_mask (torch.Tensor): VAD in TF plane. Bool or Float.
             See asteroid.dsp.vad.ebased_vad.
 
@@ -24,13 +24,14 @@ def deep_clustering_loss(embedding, tgt_index, binary_mask=None):
         >>> loss = deep_clustering_loss(embedding, targets)
 
     Reference
-        - [1] Zhong-Qiu Wang, Jonathan Le Roux, John R. Hershey
+        [1] Zhong-Qiu Wang, Jonathan Le Roux, John R. Hershey
         "ALTERNATIVE OBJECTIVE FUNCTIONS FOR DEEP CLUSTERING"
 
-    .. note:: Be careful in viewing the embedding tensors. The target indices
-        `tgt_index` are of shape (batch, freq, frames). Even if the embedding
-        is of shape (batch, freq*frames, emb), the underlying view should be
-        (batch, freq, frames, emb) and not (batch, frames, freq, emb).
+    .. note::
+        Be careful in viewing the embedding tensors. The target indices
+        ``tgt_index`` are of shape :math:`(batch, freq, frames)`. Even if the embedding
+        is of shape :math:`(batch, freq * frames, emb)`, the underlying view should be
+        :math:`(batch, freq, frames, emb)` and not :math:`(batch, frames, freq, emb)`.
     """
     spk_cnt = len(tgt_index.unique())
 

--- a/asteroid/losses/mixit_wrapper.py
+++ b/asteroid/losses/mixit_wrapper.py
@@ -9,12 +9,12 @@ class MixITLossWrapper(nn.Module):
 
     Args:
         loss_func: function with signature (est_targets, targets, **kwargs).
-        generalized (bool): Determines how MixIT is applied. If False (default),
+        generalized (bool): Determines how MixIT is applied. If False ,
             apply MixIT for any number of mixtures as soon as they contain
             the same number of sources (:meth:`~MixITLossWrapper.best_part_mixit`.)
-            If True, apply MixIT for two mixtures, but those mixtures do not
+            If True (default), apply MixIT for two mixtures, but those mixtures do not
             necessarly have to contain the same number of sources.
-            See :meth:`~MixITLossWrapper.best_part_mixit_gen`.
+            See :meth:`~MixITLossWrapper.best_part_mixit_generalized`.
 
     For each of these modes, the best partition and reordering will be
     automatically computed.
@@ -30,7 +30,7 @@ class MixITLossWrapper(nn.Module):
 
     References
         [1] Scott Wisdom et al. "Unsupervised sound separation using
-            mixtures of mixtures." arXiv:2006.12701 (2020)
+        mixtures of mixtures." arXiv:2006.12701 (2020)
     """
 
     def __init__(self, loss_func, generalized=True):
@@ -39,12 +39,12 @@ class MixITLossWrapper(nn.Module):
         self.generalized = generalized
 
     def forward(self, est_targets, targets, return_est=False, **kwargs):
-        """Find the best partition and return the loss.
+        r"""Find the best partition and return the loss.
 
         Args:
-            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+            est_targets: torch.Tensor. Expected shape :math:`(batch, nsrc, *)`.
                 The batch of target estimates.
-            targets: torch.Tensor. Expected shape [batch, nmix, *].
+            targets: torch.Tensor. Expected shape :math:`(batch, nmix, ...)`.
                 The batch of training targets
             return_est: Boolean. Whether to return the estimated mixtures
                 estimates (To compute metrics or to save example).
@@ -53,10 +53,9 @@ class MixITLossWrapper(nn.Module):
 
         Returns:
             - Best partition loss for each batch sample, average over
-                the batch. torch.Tensor(loss_value)
-            - The estimated mixtures (estimated sources summed according
-                to the partition) if return_est is True.
-                torch.Tensor of shape [batch, nmix, *].
+              the batch. torch.Tensor(loss_value)
+            - The estimated mixtures (estimated sources summed according to the partition)
+              if return_est is True. torch.Tensor of shape :math:`(batch, nmix, ...)`.
         """
         # Check input dimensions
         assert est_targets.shape[0] == targets.shape[0]
@@ -80,28 +79,27 @@ class MixITLossWrapper(nn.Module):
 
     @staticmethod
     def best_part_mixit(loss_func, est_targets, targets, **kwargs):
-        """Find best partition of the estimated sources that gives the minimum
-         loss for the MixIT training paradigm in [1]. Valid for any number of
-         mixtures as soon as they contain the same number of sources.
+        r"""Find best partition of the estimated sources that gives the minimum
+        loss for the MixIT training paradigm in [1]. Valid for any number of
+        mixtures as soon as they contain the same number of sources.
 
         Args:
-            loss_func: function with signature (est_targets, targets, **kwargs)
+            loss_func: function with signature ``(est_targets, targets, **kwargs)``
                 The loss function to get batch losses from.
-            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+            est_targets: torch.Tensor. Expected shape :math:`(batch, nsrc, ...)`.
                 The batch of target estimates.
-            targets: torch.Tensor. Expected shape [batch, nmix, *].
+            targets: torch.Tensor. Expected shape :math:`(batch, nmix, ...)`.
                 The batch of training targets (mixtures).
             **kwargs: additional keyword argument that will be passed to the
                 loss function.
 
         Returns:
-            tuple:
-                :class:`torch.Tensor`: The loss corresponding to the best
-                permutation of size (batch,).
+            :class:`torch.Tensor`: The loss corresponding to the best
+            permutation of size (batch,).
 
-                :class:`torch.LongTensor`: The indices of the best partition.
+            :class:`torch.LongTensor`: The indices of the best partition.
 
-                :class:`list`: list of the possible partitions of the sources.
+            :class:`list`: list of the possible partitions of the sources.
 
         """
         nmix = targets.shape[1]
@@ -135,29 +133,28 @@ class MixITLossWrapper(nn.Module):
 
     @staticmethod
     def best_part_mixit_generalized(loss_func, est_targets, targets, **kwargs):
-        """Find best partition of the estimated sources that gives the minimum
+        r"""Find best partition of the estimated sources that gives the minimum
         loss for the MixIT training paradigm in [1]. Valid only for two mixtures,
         but those mixtures do not necessarly have to contain the same number of
         sources e.g the case where one mixture is silent is allowed..
 
         Args:
-            loss_func: function with signature (est_targets, targets, **kwargs)
+            loss_func: function with signature ``(est_targets, targets, **kwargs)``
                 The loss function to get batch losses from.
-            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+            est_targets: torch.Tensor. Expected shape :math:`(batch, nsrc, ...)`.
                 The batch of target estimates.
-            targets: torch.Tensor. Expected shape [batch, nmix, *].
+            targets: torch.Tensor. Expected shape :math:`(batch, nmix, ...)`.
                 The batch of training targets (mixtures).
             **kwargs: additional keyword argument that will be passed to the
                 loss function.
 
         Returns:
-            tuple:
-                :class:`torch.Tensor`: The loss corresponding to the best
-                permutation of size (batch,).
+            :class:`torch.Tensor`: The loss corresponding to the best
+            permutation of size (batch,).
 
-                :class:`torch.LongTensor`: The indexes of the best permutations.
+            :class:`torch.LongTensor`: The indexes of the best permutations.
 
-                :class:`list`: list of the possible partitions of the sources.
+            :class:`list`: list of the possible partitions of the sources.
         """
         nmix = targets.shape[1]  # number of mixtures
         nsrc = est_targets.shape[1]  # number of estimated sources
@@ -201,16 +198,15 @@ class MixITLossWrapper(nn.Module):
         """Reorder sources according to the best partition.
 
         Args:
-            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+            est_targets: torch.Tensor. Expected shape :math:`(batch, nsrc, ...)`.
                 The batch of target estimates.
-            targets: torch.Tensor. Expected shape [batch, nmix, *].
+            targets: torch.Tensor. Expected shape :math:`(batch, nmix, ...)`.
                 The batch of training targets.
             min_loss_idx: torch.LongTensor. The indexes of the best permutations.
             parts: list of the possible partitions of the sources.
 
         Returns:
-            :class:`torch.Tensor`:
-                Reordered sources of shape [batch, nmix, time].
+            :class:`torch.Tensor`: Reordered sources of shape :math:`(batch, nmix, time)`.
 
         """
         # For each batch there is a different min_loss_idx

--- a/asteroid/losses/mixit_wrapper.py
+++ b/asteroid/losses/mixit_wrapper.py
@@ -94,12 +94,14 @@ class MixITLossWrapper(nn.Module):
                 loss function.
 
         Returns:
-            :class:`torch.Tensor`: The loss corresponding to the best
-            permutation of size (batch,).
+            - :class:`torch.Tensor`:
+              The loss corresponding to the best permutation of size (batch,).
 
-            :class:`torch.LongTensor`: The indices of the best partition.
+            - :class:`torch.LongTensor`:
+              The indices of the best partition.
 
-            :class:`list`: list of the possible partitions of the sources.
+            - :class:`list`:
+              list of the possible partitions of the sources.
 
         """
         nmix = targets.shape[1]
@@ -149,12 +151,14 @@ class MixITLossWrapper(nn.Module):
                 loss function.
 
         Returns:
-            :class:`torch.Tensor`: The loss corresponding to the best
-            permutation of size (batch,).
+            - :class:`torch.Tensor`:
+              The loss corresponding to the best permutation of size (batch,).
 
-            :class:`torch.LongTensor`: The indexes of the best permutations.
+            - :class:`torch.LongTensor`:
+              The indexes of the best permutations.
 
-            :class:`list`: list of the possible partitions of the sources.
+            - :class:`list`:
+              list of the possible partitions of the sources.
         """
         nmix = targets.shape[1]  # number of mixtures
         nsrc = est_targets.shape[1]  # number of estimated sources

--- a/asteroid/losses/mse.py
+++ b/asteroid/losses/mse.py
@@ -2,16 +2,14 @@ from torch.nn.modules.loss import _Loss
 
 
 class PairwiseMSE(_Loss):
-    """Measure pairwise mean square error on a batch.
+    r"""Measure pairwise mean square error on a batch.
 
     Shape:
-        est_targets (:class:`torch.Tensor`): Expected shape [batch, nsrc, *].
-            The batch of target estimates.
-        targets (:class:`torch.Tensor`): Expected shape [batch, nsrc, *].
-            The batch of training targets
+        - est_targets : :math:`(batch, nsrc, ...)`.
+        - targets: :math:`(batch, nsrc, ...)`.
 
     Returns:
-        :class:`torch.Tensor`: with shape [batch, nsrc, nsrc]
+        :class:`torch.Tensor`: with shape :math:`(batch, nsrc, nsrc)`
 
     Examples
         >>> import torch
@@ -36,17 +34,15 @@ class PairwiseMSE(_Loss):
 
 
 class SingleSrcMSE(_Loss):
-    """Measure mean square error on a batch.
+    r"""Measure mean square error on a batch.
     Supports both tensors with and without source axis.
 
     Shape:
-        est_targets (:class:`torch.Tensor`): Expected shape [batch, *].
-            The batch of target estimates.
-        targets (:class:`torch.Tensor`): Expected shape [batch, *].
-            The batch of training targets.
+        - est_targets: :math:`(batch, ...)`.
+        - targets: :math:`(batch, ...)`.
 
     Returns:
-        :class:`torch.Tensor`: with shape [batch]
+        :class:`torch.Tensor`: with shape :math:`(batch)`
 
     Examples
         >>> import torch

--- a/asteroid/losses/multi_scale_spectral.py
+++ b/asteroid/losses/multi_scale_spectral.py
@@ -6,7 +6,7 @@ from asteroid_filterbanks.transforms import mag
 
 
 class SingleSrcMultiScaleSpectral(_Loss):
-    """Measure multi-scale spectral loss as described in [1]
+    r"""Measure multi-scale spectral loss as described in [1]
 
     Args:
         n_filters (list): list containing the number of filter desired for
@@ -17,11 +17,8 @@ class SingleSrcMultiScaleSpectral(_Loss):
             each STFT
 
     Shape:
-        est_targets (:class:`torch.Tensor`): Expected shape [batch, time].
-            Batch of target estimates.
-        targets (:class:`torch.Tensor`): Expected shape [batch, time].
-            Batch of training targets.
-        alpha (float) : Weighting factor for the log term
+        - est_targets : :math:`(batch, time)`.
+        - targets: :math:`(batch, time)`.
 
     Returns:
         :class:`torch.Tensor`: with shape [batch]
@@ -44,7 +41,7 @@ class SingleSrcMultiScaleSpectral(_Loss):
         >>> loss = loss_func(est_targets, targets)
 
     References
-        - [1] Jesse Engel and Lamtharn (Hanoi) Hantrakul and Chenjie Gu and
+        [1] Jesse Engel and Lamtharn (Hanoi) Hantrakul and Chenjie Gu and
         Adam Roberts "DDSP: Differentiable Digital Signal Processing" ICLR 2020.
     """
 

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -163,10 +163,10 @@ class PITLossWrapper(nn.Module):
 
     @staticmethod
     def best_perm_from_perm_avg_loss(loss_func, est_targets, targets, **kwargs):
-        """Find best permutation from loss function with source axis.
+        r"""Find best permutation from loss function with source axis.
 
         Args:
-            loss_func: function with signature (est_targets, targets, **kwargs)
+            loss_func: function with signature $(est_targets, targets, **kwargs)$
                 The loss function batch losses from.
             est_targets: torch.Tensor. Expected shape $(batch, nsrc, *)$.
                 The batch of target estimates.
@@ -176,10 +176,9 @@ class PITLossWrapper(nn.Module):
                 loss function.
 
         Returns:
-            - :class:`torch.Tensor`: The loss corresponding to the best
-              permutation of size (batch,).
+            torch.Tensor: The loss corresponding to the best permutation of size $(batch,)$.
 
-            - :class:`torch.Tensor`: The indices of the best permutations.
+            torch.Tensor: The indices of the best permutations.
         """
         n_src = targets.shape[1]
         perms = torch.tensor(list(permutations(range(n_src))), dtype=torch.long)
@@ -205,15 +204,15 @@ class PITLossWrapper(nn.Module):
                 Tensor of shape :math:`(batch, n\_src, n\_src)`. Pairwise losses.
             perm_reduce (Callable): torch function to reduce permutation losses.
                 Defaults to None (equivalent to mean). Signature of the func
-                (pwl_set, **kwargs) : :math:`(B, n\_src!, n\_src) --> (B, n\_src!)`
+                (pwl_set, **kwargs) : :math:`(B, n\_src!, n\_src) -> (B, n\_src!)`
             **kwargs: additional keyword argument that will be passed to the
                 permutation reduce function.
 
         Returns:
-            - :class:`torch.Tensor`: The loss corresponding to the best
-              permutation of size (batch,).
+            :class:`torch.Tensor`: The loss corresponding to the best
+            permutation of size $(batch,)$.
 
-            - :class:`torch.Tensor`: The indices of the best permutations.
+            :class:`torch.Tensor`: The indices of the best permutations.
         """
         n_src = pair_wise_losses.shape[-1]
         if perm_reduce is not None or n_src <= 3:
@@ -234,8 +233,7 @@ class PITLossWrapper(nn.Module):
                 Contains optimal permutation indices for each batch.
 
         Returns:
-            :class:`torch.Tensor`:
-                Reordered sources of shape :math:.
+            :class:`torch.Tensor`: Reordered sources.
         """
         reordered_sources = torch.stack(
             [torch.index_select(s, 0, b) for s, b in zip(source, batch_indices)]
@@ -244,7 +242,7 @@ class PITLossWrapper(nn.Module):
 
     @staticmethod
     def find_best_perm_factorial(pair_wise_losses, perm_reduce=None, **kwargs):
-        """Find the best permutation given the pair-wise losses by looping
+        r"""Find the best permutation given the pair-wise losses by looping
         through all the permutations.
 
         Args:
@@ -252,16 +250,15 @@ class PITLossWrapper(nn.Module):
                 Tensor of shape :math:. Pairwise losses.
             perm_reduce (Callable): torch function to reduce permutation losses.
                 Defaults to None (equivalent to mean). Signature of the func
-                (pwl_set, **kwargs) : :math:`(B, n\_src!, n\_src) --> (B, n\_src!)`
+                (pwl_set, **kwargs) : :math:`(B, n\_src!, n\_src) -> (B, n\_src!)`
             **kwargs: additional keyword argument that will be passed to the
                 permutation reduce function.
 
         Returns:
-            tuple:
-                :class:`torch.Tensor`: The loss corresponding to the best
-                permutation of size (batch,).
+            :class:`torch.Tensor`: The loss corresponding to the best
+            permutation of size $(batch,)$.
 
-                :class:`torch.Tensor`: The indices of the best permutations.
+            :class:`torch.Tensor`: The indices of the best permutations.
 
         MIT Copyright (c) 2018 Kaituo XU.
         See `Original code
@@ -295,19 +292,14 @@ class PITLossWrapper(nn.Module):
 
     @staticmethod
     def find_best_perm_hungarian(pair_wise_losses: torch.Tensor):
-        """Find the best permutation given the pair-wise losses, using the
-        Hungarian algorithm.
-
-        Args:
-            pair_wise_losses (:class:`torch.Tensor`):
-                Tensor of shape :math:. Pairwise losses.
+        """
+        Find the best permutation given the pair-wise losses, using the Hungarian algorithm.
 
         Returns:
-            tuple:
-                :class:`torch.Tensor`: The loss corresponding to the best
-                permutation of size (batch,).
+            :class:`torch.Tensor`: The loss corresponding to the best
+            permutation of size (batch,).
 
-                :class:`torch.Tensor`: The indices of the best permutations.
+            :class:`torch.Tensor`: The indices of the best permutations.
         """
         # After transposition, dim 1 corresp. to sources and dim 2 to estimates
         pwl = pair_wise_losses.transpose(-1, -2)

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -225,11 +225,11 @@ class PITLossWrapper(nn.Module):
 
     @staticmethod
     def reorder_source(source, batch_indices):
-        """Reorder sources according to the best permutation.
+        r"""Reorder sources according to the best permutation.
 
         Args:
-            source (torch.Tensor): Tensor of shape :math:
-            batch_indices (torch.Tensor): Tensor of shape :math:.
+            source (torch.Tensor): Tensor of shape :math:`(batch, n_src, time)`
+            batch_indices (torch.Tensor): Tensor of shape :math:`(batch, n_src)`.
                 Contains optimal permutation indices for each batch.
 
         Returns:
@@ -247,7 +247,7 @@ class PITLossWrapper(nn.Module):
 
         Args:
             pair_wise_losses (:class:`torch.Tensor`):
-                Tensor of shape :math:. Pairwise losses.
+                Tensor of shape :math:`(batch, n_src, n_src)`. Pairwise losses.
             perm_reduce (Callable): torch function to reduce permutation losses.
                 Defaults to None (equivalent to mean). Signature of the func
                 (pwl_set, **kwargs) : :math:`(B, n\_src!, n\_src) -> (B, n\_src!)`

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -176,9 +176,11 @@ class PITLossWrapper(nn.Module):
                 loss function.
 
         Returns:
-            torch.Tensor: The loss corresponding to the best permutation of size $(batch,)$.
+            - :class:`torch.Tensor`:
+                The loss corresponding to the best permutation of size $(batch,)$.
 
-            torch.Tensor: The indices of the best permutations.
+            - :class:`torch.Tensor`:
+                The indices of the best permutations.
         """
         n_src = targets.shape[1]
         perms = torch.tensor(list(permutations(range(n_src))), dtype=torch.long)
@@ -209,10 +211,11 @@ class PITLossWrapper(nn.Module):
                 permutation reduce function.
 
         Returns:
-            :class:`torch.Tensor`: The loss corresponding to the best
-            permutation of size $(batch,)$.
+            - :class:`torch.Tensor`:
+              The loss corresponding to the best permutation of size $(batch,)$.
 
-            :class:`torch.Tensor`: The indices of the best permutations.
+            - :class:`torch.Tensor`:
+              The indices of the best permutations.
         """
         n_src = pair_wise_losses.shape[-1]
         if perm_reduce is not None or n_src <= 3:
@@ -255,10 +258,11 @@ class PITLossWrapper(nn.Module):
                 permutation reduce function.
 
         Returns:
-            :class:`torch.Tensor`: The loss corresponding to the best
-            permutation of size $(batch,)$.
+            - :class:`torch.Tensor`:
+              The loss corresponding to the best permutation of size $(batch,)$.
 
-            :class:`torch.Tensor`: The indices of the best permutations.
+            - :class:`torch.Tensor`:
+              The indices of the best permutations.
 
         MIT Copyright (c) 2018 Kaituo XU.
         See `Original code
@@ -296,10 +300,11 @@ class PITLossWrapper(nn.Module):
         Find the best permutation given the pair-wise losses, using the Hungarian algorithm.
 
         Returns:
-            :class:`torch.Tensor`: The loss corresponding to the best
-            permutation of size (batch,).
+            - :class:`torch.Tensor`:
+              The loss corresponding to the best permutation of size (batch,).
 
-            :class:`torch.Tensor`: The indices of the best permutations.
+            - :class:`torch.Tensor`:
+              The indices of the best permutations.
         """
         # After transposition, dim 1 corresp. to sources and dim 2 to estimates
         pwl = pair_wise_losses.transpose(-1, -2)

--- a/asteroid/losses/pit_wrapper.py
+++ b/asteroid/losses/pit_wrapper.py
@@ -14,13 +14,13 @@ class PITLossWrapper(nn.Module):
             * ``'pw_mtx'`` (pairwise matrix): `loss_func` computes pairwise
               losses and returns a torch.Tensor of shape
               :math:`(batch, n\_src, n\_src)`. Each element
-              :math:`[batch, i, j]` corresponds to the loss between
+              :math:`(batch, i, j)` corresponds to the loss between
               :math:`targets[:, i]` and :math:`est\_targets[:, j]`
             * ``'pw_pt'`` (pairwise point): `loss_func` computes the loss for
               a batch of single source and single estimates (tensors won't
               have the source axis). Output shape : :math:`(batch)`.
               See :meth:`~PITLossWrapper.get_pw_losses`.
-            * ``'perm_avg'``(permutation average): `loss_func` computes the
+            * ``'perm_avg'`` (permutation average): `loss_func` computes the
               average loss for a given permutations of the sources and
               estimates. Output shape : :math:`(batch)`.
               See :meth:`~PITLossWrapper.best_perm_from_perm_avg_loss`.
@@ -29,14 +29,16 @@ class PITLossWrapper(nn.Module):
 
         perm_reduce (Callable): torch function to reduce permutation losses.
             Defaults to None (equivalent to mean). Signature of the func
-            (pwl_set, **kwargs) : (B, n_src!, n_src) --> (B, n_src!).
+            (pwl_set, **kwargs) : :math:`(B, n\_src!, n\_src) --> (B, n\_src!)`.
             `perm_reduce` can receive **kwargs during forward using the
             `reduce_kwargs` argument (dict). If those argument are static,
             consider defining a small function or using `functools.partial`.
             Only used in `'pw_mtx'` and `'pw_pt'` `pit_from` modes.
 
     For each of these modes, the best permutation and reordering will be
-    automatically computed.
+    automatically computed. When either ``'pw_mtx'`` or ``'pw_pt'`` is used,
+    and the number of sources is larger than three, the hungarian algorithm is
+    used to find the best permutation.
 
     Examples
         >>> import torch
@@ -71,12 +73,12 @@ class PITLossWrapper(nn.Module):
             )
 
     def forward(self, est_targets, targets, return_est=False, reduce_kwargs=None, **kwargs):
-        """Find the best permutation and return the loss.
+        r"""Find the best permutation and return the loss.
 
         Args:
-            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+            est_targets: torch.Tensor. Expected shape $(batch, nsrc, ...)$.
                 The batch of target estimates.
-            targets: torch.Tensor. Expected shape [batch, nsrc, *].
+            targets: torch.Tensor. Expected shape $(batch, nsrc, ...)$.
                 The batch of training targets
             return_est: Boolean. Whether to return the reordered targets
                 estimates (To compute metrics or to save example).
@@ -87,9 +89,9 @@ class PITLossWrapper(nn.Module):
 
         Returns:
             - Best permutation loss for each batch sample, average over
-                the batch. torch.Tensor(loss_value)
-            - The reordered targets estimates if return_est is True.
-                torch.Tensor of shape [batch, nsrc, *].
+              the batch.
+            - The reordered targets estimates if ``return_est`` is True.
+              :class:`torch.Tensor` of shape $(batch, nsrc, ...)$.
         """
         n_src = targets.shape[1]
         assert n_src < 10, f"Expected source axis along dim 1, found {n_src}"
@@ -131,25 +133,25 @@ class PITLossWrapper(nn.Module):
 
     @staticmethod
     def get_pw_losses(loss_func, est_targets, targets, **kwargs):
-        """Get pair-wise losses between the training targets and its estimate
+        r"""Get pair-wise losses between the training targets and its estimate
         for a given loss function.
 
         Args:
             loss_func: function with signature (est_targets, targets, **kwargs)
                 The loss function to get pair-wise losses from.
-            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+            est_targets: torch.Tensor. Expected shape $(batch, nsrc, ...)$.
                 The batch of target estimates.
-            targets: torch.Tensor. Expected shape [batch, nsrc, *].
+            targets: torch.Tensor. Expected shape $(batch, nsrc, ...)$.
                 The batch of training targets.
             **kwargs: additional keyword argument that will be passed to the
                 loss function.
 
         Returns:
-            torch.Tensor or size [batch, nsrc, nsrc], losses computed for
+            torch.Tensor or size $(batch, nsrc, nsrc)$, losses computed for
             all permutations of the targets and est_targets.
 
         This function can be called on a loss function which returns a tensor
-        of size [batch]. There are more efficient ways to compute pair-wise
+        of size :math:`(batch)`. There are more efficient ways to compute pair-wise
         losses using broadcasting.
         """
         batch_size, n_src, *_ = targets.shape
@@ -166,19 +168,18 @@ class PITLossWrapper(nn.Module):
         Args:
             loss_func: function with signature (est_targets, targets, **kwargs)
                 The loss function batch losses from.
-            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+            est_targets: torch.Tensor. Expected shape $(batch, nsrc, *)$.
                 The batch of target estimates.
-            targets: torch.Tensor. Expected shape [batch, nsrc, *].
+            targets: torch.Tensor. Expected shape $(batch, nsrc, *)$.
                 The batch of training targets.
             **kwargs: additional keyword argument that will be passed to the
                 loss function.
 
         Returns:
-            tuple:
-                :class:`torch.Tensor`: The loss corresponding to the best
-                permutation of size (batch,).
+            - :class:`torch.Tensor`: The loss corresponding to the best
+              permutation of size (batch,).
 
-                :class:`torch.Tensor`: The indices of the best permutations.
+            - :class:`torch.Tensor`: The indices of the best permutations.
         """
         n_src = targets.shape[1]
         perms = torch.tensor(list(permutations(range(n_src))), dtype=torch.long)
@@ -193,27 +194,26 @@ class PITLossWrapper(nn.Module):
 
     @staticmethod
     def find_best_perm(pair_wise_losses, perm_reduce=None, **kwargs):
-        """Find the best permutation, given the pair-wise losses.
+        r"""Find the best permutation, given the pair-wise losses.
 
         Dispatch between factorial method if number of sources is small (<3)
-        and hungarian method for more sources. If `perm_reduce` is not None,
+        and hungarian method for more sources. If ``perm_reduce`` is not None,
         the factorial method is always used.
 
         Args:
             pair_wise_losses (:class:`torch.Tensor`):
-                Tensor of shape [batch, n_src, n_src]. Pairwise losses.
+                Tensor of shape :math:`(batch, n\_src, n\_src)`. Pairwise losses.
             perm_reduce (Callable): torch function to reduce permutation losses.
                 Defaults to None (equivalent to mean). Signature of the func
-                (pwl_set, **kwargs) : (B, n_src!, n_src) --> (B, n_src!)
+                (pwl_set, **kwargs) : :math:`(B, n\_src!, n\_src) --> (B, n\_src!)`
             **kwargs: additional keyword argument that will be passed to the
                 permutation reduce function.
 
         Returns:
-            tuple:
-                :class:`torch.Tensor`: The loss corresponding to the best
-                permutation of size (batch,).
+            - :class:`torch.Tensor`: The loss corresponding to the best
+              permutation of size (batch,).
 
-                :class:`torch.Tensor`: The indices of the best permutations.
+            - :class:`torch.Tensor`: The indices of the best permutations.
         """
         n_src = pair_wise_losses.shape[-1]
         if perm_reduce is not None or n_src <= 3:
@@ -229,13 +229,13 @@ class PITLossWrapper(nn.Module):
         """Reorder sources according to the best permutation.
 
         Args:
-            source (torch.Tensor): Tensor of shape [batch, n_src, time]
-            batch_indices (torch.Tensor): Tensor of shape [batch, n_src].
+            source (torch.Tensor): Tensor of shape :math:
+            batch_indices (torch.Tensor): Tensor of shape :math:.
                 Contains optimal permutation indices for each batch.
 
         Returns:
             :class:`torch.Tensor`:
-                Reordered sources of shape [batch, n_src, time].
+                Reordered sources of shape :math:.
         """
         reordered_sources = torch.stack(
             [torch.index_select(s, 0, b) for s, b in zip(source, batch_indices)]
@@ -249,10 +249,10 @@ class PITLossWrapper(nn.Module):
 
         Args:
             pair_wise_losses (:class:`torch.Tensor`):
-                Tensor of shape [batch, n_src, n_src]. Pairwise losses.
+                Tensor of shape :math:. Pairwise losses.
             perm_reduce (Callable): torch function to reduce permutation losses.
                 Defaults to None (equivalent to mean). Signature of the func
-                (pwl_set, **kwargs) : (B, n_src!, n_src) --> (B, n_src!)
+                (pwl_set, **kwargs) : :math:`(B, n\_src!, n\_src) --> (B, n\_src!)`
             **kwargs: additional keyword argument that will be passed to the
                 permutation reduce function.
 
@@ -300,7 +300,7 @@ class PITLossWrapper(nn.Module):
 
         Args:
             pair_wise_losses (:class:`torch.Tensor`):
-                Tensor of shape [batch, n_src, n_src]. Pairwise losses.
+                Tensor of shape :math:. Pairwise losses.
 
         Returns:
             tuple:

--- a/asteroid/losses/pmsqe.py
+++ b/asteroid/losses/pmsqe.py
@@ -27,10 +27,11 @@ class SingleSrcPMSQE(nn.Module):
         sample_rate (int): Sample rate of the input audio.
 
     References
-        - [1] J.M.Martin, A.M.Gomez, J.A.Gonzalez, A.M.Peinado 'A Deep Learning
+        [1] J.M.Martin, A.M.Gomez, J.A.Gonzalez, A.M.Peinado 'A Deep Learning
         Loss Function based on the Perceptual Evaluation of the
         Speech Quality', IEEE Signal Processing Letters, 2018.
         Implemented by Juan M. Martin. Contact: mdjuamart@ugr.es
+
         Copyright 2019: University of Granada, Signal Processing, Multimedia
         Transmission and Speech/Audio Technologies (SigMAT) Group.
 

--- a/asteroid/losses/sdr.py
+++ b/asteroid/losses/sdr.py
@@ -3,27 +3,23 @@ from torch.nn.modules.loss import _Loss
 
 
 class PairwiseNegSDR(_Loss):
-    """Base class for pairwise negative SI-SDR, SD-SDR and SNR on a batch.
+    r"""Base class for pairwise negative SI-SDR, SD-SDR and SNR on a batch.
 
     Args:
-        sdr_type (str): choose between "snr" for plain SNR, "sisdr" for
-            SI-SDR and "sdsdr" for SD-SDR [1].
+        sdr_type (str): choose between ``snr`` for plain SNR, ``sisdr`` for
+            SI-SDR and ``sdsdr`` for SD-SDR [1].
         zero_mean (bool, optional): by default it zero mean the target
             and estimate before computing the loss.
         take_log (bool, optional): by default the log10 of sdr is returned.
 
     Shape:
-        est_targets (:class:`torch.Tensor`): Expected shape
-            [batch, n_src, time]. Batch of target estimates.
-        targets (:class:`torch.Tensor`): Expected shape
-            [batch, n_src, time]. Batch of training targets.
+        - est_targets : :math:`(batch, nsrc, ...)`.
+        - targets: :math:`(batch, nsrc, ...)`.
 
     Returns:
-        :class:`torch.Tensor`: with shape [batch, n_src, n_src].
-        Pairwise losses.
+        :class:`torch.Tensor`: with shape :math:`(batch, nsrc, nsrc)`. Pairwise losses.
 
     Examples
-
         >>> import torch
         >>> from asteroid.losses import PITLossWrapper
         >>> targets = torch.randn(10, 2, 32000)
@@ -33,7 +29,7 @@ class PairwiseNegSDR(_Loss):
         >>> loss = loss_func(est_targets, targets)
 
     References
-        - [1] Le Roux, Jonathan, et al. "SDR half-baked or well done." IEEE
+        [1] Le Roux, Jonathan, et al. "SDR half-baked or well done." IEEE
         International Conference on Acoustics, Speech and Signal
         Processing (ICASSP) 2019.
     """
@@ -86,32 +82,29 @@ class PairwiseNegSDR(_Loss):
 
 
 class SingleSrcNegSDR(_Loss):
-    """Base class for single-source negative SI-SDR, SD-SDR and SNR.
+    r"""Base class for single-source negative SI-SDR, SD-SDR and SNR.
 
     Args:
-        sdr_type (string): choose between "snr" for plain SNR, "sisdr" for
-            SI-SDR and "sdsdr" for SD-SDR [1].
+        sdr_type (str): choose between ``snr`` for plain SNR, ``sisdr`` for
+            SI-SDR and ``sdsdr`` for SD-SDR [1].
         zero_mean (bool, optional): by default it zero mean the target and
             estimate before computing the loss.
         take_log (bool, optional): by default the log10 of sdr is returned.
         reduction (string, optional): Specifies the reduction to apply to
             the output:
-        ``'none'`` | ``'mean'``. ``'none'``: no reduction will be applied,
-        ``'mean'``: the sum of the output will be divided by the number of
-        elements in the output.
+            ``'none'`` | ``'mean'``. ``'none'``: no reduction will be applied,
+            ``'mean'``: the sum of the output will be divided by the number of
+            elements in the output.
 
     Shape:
-        est_targets (:class:`torch.Tensor`): Expected shape [batch, time].
-            Batch of target estimates.
-        targets (:class:`torch.Tensor`): Expected shape [batch, time].
-            Batch of training targets.
+        - est_targets : :math:`(batch, time)`.
+        - targets: :math:`(batch, time)`.
 
     Returns:
-        :class:`torch.Tensor`: with shape [batch] if reduction='none' else
-            [] scalar if reduction='mean'.
+        :class:`torch.Tensor`: with shape :math:`(batch)` if ``reduction='none'`` else
+        [] scalar if ``reduction='mean'``.
 
     Examples
-
         >>> import torch
         >>> from asteroid.losses import PITLossWrapper
         >>> targets = torch.randn(10, 2, 32000)
@@ -121,7 +114,7 @@ class SingleSrcNegSDR(_Loss):
         >>> loss = loss_func(est_targets, targets)
 
     References
-        - [1] Le Roux, Jonathan, et al. "SDR half-baked or well done." IEEE
+        [1] Le Roux, Jonathan, et al. "SDR half-baked or well done." IEEE
         International Conference on Acoustics, Speech and Signal
         Processing (ICASSP) 2019.
     """
@@ -171,28 +164,25 @@ class SingleSrcNegSDR(_Loss):
 
 
 class MultiSrcNegSDR(_Loss):
-    """Base class for computing negative SI-SDR, SD-SDR and SNR for a given
+    r"""Base class for computing negative SI-SDR, SD-SDR and SNR for a given
     permutation of source and their estimates.
 
     Args:
-        sdr_type (string): choose between "snr" for plain SNR, "sisdr" for
-            SI-SDR and "sdsdr" for SD-SDR [1].
+        sdr_type (str): choose between ``snr`` for plain SNR, ``sisdr`` for
+            SI-SDR and ``sdsdr`` for SD-SDR [1].
         zero_mean (bool, optional): by default it zero mean the target
             and estimate before computing the loss.
         take_log (bool, optional): by default the log10 of sdr is returned.
 
     Shape:
-        est_targets (:class:`torch.Tensor`): Expected shape [batch, n_src, time].
-            Batch of target estimates.
-        targets (:class:`torch.Tensor`): Expected shape [batch, n_src, time].
-            Batch of training targets.
+        - est_targets : :math:`(batch, nsrc, time)`.
+        - targets: :math:`(batch, nsrc, time)`.
 
     Returns:
-        :class:`torch.Tensor`: with shape [batch] if reduction='none' else
-            [] scalar if reduction='mean'.
+        :class:`torch.Tensor`: with shape :math:`(batch)` if ``reduction='none'`` else
+        [] scalar if ``reduction='mean'``.
 
     Examples
-
         >>> import torch
         >>> from asteroid.losses import PITLossWrapper
         >>> targets = torch.randn(10, 2, 32000)
@@ -202,7 +192,7 @@ class MultiSrcNegSDR(_Loss):
         >>> loss = loss_func(est_targets, targets)
 
     References
-        - [1] Le Roux, Jonathan, et al. "SDR half-baked or well done." IEEE
+        [1] Le Roux, Jonathan, et al. "SDR half-baked or well done." IEEE
         International Conference on Acoustics, Speech and Signal
         Processing (ICASSP) 2019.
 

--- a/asteroid/losses/sinkpit_wrapper.py
+++ b/asteroid/losses/sinkpit_wrapper.py
@@ -15,15 +15,11 @@ class SinkPITLossWrapper(nn.Module):
         hungarian_validation (boolean) : Whether to use the Hungarian algorithm
             for the validation. (default = True)
 
-        `loss_func` computes pairwise
-        losses and returns a torch.Tensor of shape
-        :math:`(batch, n\_src, n\_src)`. Each element
-        :math:`[batch, i, j]` corresponds to the loss between
-        :math:`targets[:, i]` and :math:`est\_targets[:, j]`
-        It evaluates an approximate value of the PIT loss
-        using Sinkhorn's iterative algorithm.
-        See :meth:`~PITLossWrapper.best_softperm_sinkhorn`
-        and http://arxiv.org/abs/2010.11871
+    ``loss_func`` computes pairwise losses and returns a torch.Tensor of shape
+    :math:`(batch, n\_src, n\_src)`. Each element :math:`(batch, i, j)` corresponds to
+    the loss between :math:`targets[:, i]` and :math:`est\_targets[:, j]`
+    It evaluates an approximate value of the PIT loss using Sinkhorn's iterative algorithm.
+    See :meth:`~PITLossWrapper.best_softperm_sinkhorn` and http://arxiv.org/abs/2010.11871
 
     Examples
         >>> import torch
@@ -74,10 +70,11 @@ class SinkPITLossWrapper(nn.Module):
 
     def forward(self, est_targets, targets, return_est=False, **kwargs):
         """Evaluate the loss using Sinkhorn's algorithm.
+
         Args:
-            est_targets: torch.Tensor. Expected shape [batch, nsrc, *].
+            est_targets: torch.Tensor. Expected shape :math:`(batch, nsrc, ...)`.
                 The batch of target estimates.
-            targets: torch.Tensor. Expected shape [batch, nsrc, *].
+            targets: torch.Tensor. Expected shape :math:`(batch, nsrc, ...)`.
                 The batch of training targets
             return_est: Boolean. Whether to return the reordered targets
                 estimates (To compute metrics or to save example).
@@ -88,7 +85,7 @@ class SinkPITLossWrapper(nn.Module):
             - Best permutation loss for each batch sample, average over
                 the batch. torch.Tensor(loss_value)
             - The reordered targets estimates if return_est is True.
-                torch.Tensor of shape [batch, nsrc, *].
+                torch.Tensor of shape :math:`(batch, nsrc, ...)`.
         """
         n_src = targets.shape[1]
         assert n_src < 100, f"Expected source axis along dim 1, found {n_src}"
@@ -123,18 +120,20 @@ class SinkPITLossWrapper(nn.Module):
 
     @staticmethod
     def best_softperm_sinkhorn(pair_wise_losses, beta=10, n_iter=200):
-        """Compute an approximate PIT loss using Sinkhorn's algorithm.
+        r"""Compute an approximate PIT loss using Sinkhorn's algorithm.
         See http://arxiv.org/abs/2010.11871
+
         Args:
             pair_wise_losses (:class:`torch.Tensor`):
-                Tensor of shape [batch, n_src, n_src]. Pairwise losses.
+                Tensor of shape :math:`(batch, n_src, n_src)`. Pairwise losses.
             beta (float) : Inverse temperature parameter. (default = 10)
             n_iter (int) : Number of iteration. Even number. (default = 200)
+
         Returns:
-            tuple:
-                :class:`torch.Tensor`: The loss corresponding to the best
-                permutation of size (batch,).
-                :class:`torch.Tensor`: A soft permutation matrix.
+            :class:`torch.Tensor`: The loss corresponding to the best
+            permutation of size (batch,).
+
+            :class:`torch.Tensor`: A soft permutation matrix.
         """
         C = pair_wise_losses.transpose(-1, -2)
         n_src = C.shape[-1]
@@ -157,12 +156,10 @@ class SinkPITBetaScheduler(pl.callbacks.Callback):
     This module is used as a Callback function of `pytorch_lightning.Trainer`.
 
     Args:
-        cooling_schedule (callable) : A callable
-            that takes a parameter `epoch` (int)
+        cooling_schedule (callable) : A callable that takes a parameter `epoch` (int)
             and returns the value of `beta` (float).
 
-            The default function is `sinkpit_default_beta_schedule`.
-            :math: \beta = min(1.02^{epoch}, 10)
+    The default function is ``sinkpit_default_beta_schedule``: :math:`\beta = min(1.02^{epoch}, 10)`
 
     Example
         >>> from pytorch_lightning import Trainer

--- a/asteroid/losses/sinkpit_wrapper.py
+++ b/asteroid/losses/sinkpit_wrapper.py
@@ -130,10 +130,11 @@ class SinkPITLossWrapper(nn.Module):
             n_iter (int) : Number of iteration. Even number. (default = 200)
 
         Returns:
-            :class:`torch.Tensor`: The loss corresponding to the best
-            permutation of size (batch,).
+            - :class:`torch.Tensor`:
+              The loss corresponding to the best permutation of size (batch,).
 
-            :class:`torch.Tensor`: A soft permutation matrix.
+            - :class:`torch.Tensor`:
+              A soft permutation matrix.
         """
         C = pair_wise_losses.transpose(-1, -2)
         n_src = C.shape[-1]

--- a/asteroid/losses/sinkpit_wrapper.py
+++ b/asteroid/losses/sinkpit_wrapper.py
@@ -145,4 +145,3 @@ class SinkPITLossWrapper(nn.Module):
         min_loss = torch.einsum("bij,bij->b", C + Z / beta, torch.exp(Z))
         min_loss = min_loss / n_src
         return min_loss, torch.exp(Z)
-      

--- a/asteroid/losses/stoi.py
+++ b/asteroid/losses/stoi.py
@@ -6,10 +6,9 @@ with warnings.catch_warnings():
 
 
 class NegSTOILoss(_NegSTOILoss):
-    """Negated Short Term Objective Intelligibility (STOI) metric, to be used
-        as a loss function.
-        Inspired from [1, 2, 3] but not exactly the same : cannot be used as
-        the STOI metric directly (use pystoi instead). See Notes.
+    r"""Negated Short Term Objective Intelligibility (STOI) metric, to be used
+    as a loss function.
+    Inspired from [1, 2, 3] but not the same.
 
     Args:
         sample_rate (int): sample rate of the audio files
@@ -17,9 +16,9 @@ class NegSTOILoss(_NegSTOILoss):
         extended (bool): Whether to compute extended version [3].
 
     Shapes:
-        (time,) --> (1, )
-        (batch, time) --> (batch, )
-        (batch, n_src, time) --> (batch, n_src)
+        - :math:`(time,) -> (1, )`
+        - :math:`(batch, time) -> (batch, )`
+        - :math:`(batch, n\_src, time) -> (batch, n\_src)`
 
     Returns:
         torch.Tensor of shape (batch, *, ), only the time dimension has
@@ -48,15 +47,17 @@ class NegSTOILoss(_NegSTOILoss):
         >>> loss = loss_func(est_targets, targets)
 
     References
-        - [1] C.H.Taal, R.C.Hendriks, R.Heusdens, J.Jensen 'A Short-Time
-            Objective Intelligibility Measure for Time-Frequency Weighted Noisy
-            Speech', ICASSP 2010, Texas, Dallas.
-        - [2] C.H.Taal, R.C.Hendriks, R.Heusdens, J.Jensen 'An Algorithm for
-            Intelligibility Prediction of Time-Frequency Weighted Noisy Speech',
-            IEEE Transactions on Audio, Speech, and Language Processing, 2011.
-        - [3] Jesper Jensen and Cees H. Taal, 'An Algorithm for Predicting the
-            Intelligibility of Speech Masked by Modulated Noise Maskers',
-            IEEE Transactions on Audio, Speech and Language Processing, 2016.
+        [1] C.H.Taal, R.C.Hendriks, R.Heusdens, J.Jensen 'A Short-Time
+        Objective Intelligibility Measure for Time-Frequency Weighted Noisy
+        Speech', ICASSP 2010, Texas, Dallas.
+
+        [2] C.H.Taal, R.C.Hendriks, R.Heusdens, J.Jensen 'An Algorithm for
+        Intelligibility Prediction of Time-Frequency Weighted Noisy Speech',
+        IEEE Transactions on Audio, Speech, and Language Processing, 2011.
+
+        [3] Jesper Jensen and Cees H. Taal, 'An Algorithm for Predicting the
+        Intelligibility of Speech Masked by Modulated Noise Maskers',
+        IEEE Transactions on Audio, Speech and Language Processing, 2016.
     """
 
     def __init__(self, *args, **kwargs):

--- a/asteroid/masknn/attention.py
+++ b/asteroid/masknn/attention.py
@@ -26,9 +26,9 @@ class ImprovedTransformedLayer(nn.Module):
         norm (str, optional): Type of normalization to use.
 
     References
-        - [1] Chen, Jingjing, Qirong Mao, and Dong Liu. "Dual-Path Transformer
+        [1] Chen, Jingjing, Qirong Mao, and Dong Liu. "Dual-Path Transformer
         Network: Direct Context-Aware Modeling for End-to-End Monaural Speech Separation."
-         arXiv (2020).
+        arXiv (2020).
     """
 
     def __init__(
@@ -67,8 +67,7 @@ class ImprovedTransformedLayer(nn.Module):
 
 
 class DPTransformer(nn.Module):
-    """Dual-path Transformer
-        introduced in [1].
+    """Dual-path Transformer introduced in [1].
 
     Args:
         in_chan (int): Number of input filters.
@@ -89,9 +88,9 @@ class DPTransformer(nn.Module):
         dropout (float, optional): Dropout ratio, must be in [0,1].
 
     References
-        - [1] Chen, Jingjing, Qirong Mao, and Dong Liu. "Dual-Path Transformer
+        [1] Chen, Jingjing, Qirong Mao, and Dong Liu. "Dual-Path Transformer
         Network: Direct Context-Aware Modeling for End-to-End Monaural Speech Separation."
-         arXiv (2020).
+        arXiv (2020).
     """
 
     def __init__(
@@ -181,13 +180,13 @@ class DPTransformer(nn.Module):
             self.output_act = mask_nl_class()
 
     def forward(self, mixture_w):
-        """
+        r"""Forward.
+
         Args:
-            mixture_w (:class:`torch.Tensor`): Tensor of shape
-                [batch, n_filters, n_frames]
+            mixture_w (:class:`torch.Tensor`): Tensor of shape $(batch, nfilters, nframes)$
+
         Returns:
-            :class:`torch.Tensor`
-                estimated mask of shape [batch, n_src, n_filters, n_frames]
+            :class:`torch.Tensor`: estimated mask of shape $(batch, nsrc, nfilters, nframes)$
         """
         if self.input_layer is not None:
             mixture_w = self.input_layer(mixture_w.transpose(1, 2)).transpose(1, 2)

--- a/asteroid/masknn/convolutional.py
+++ b/asteroid/masknn/convolutional.py
@@ -32,12 +32,13 @@ class Conv1DBlock(nn.Module):
         dilation (int): Dilation of the depth-wise convolution.
         norm_type (str, optional): Type of normalization to use. To choose from
 
-            -  ``'gLN'``: global Layernorm
-            -  ``'cLN'``: channelwise Layernorm
-            -  ``'cgLN'``: cumulative global Layernorm
+            -  ``'gLN'``: global Layernorm.
+            -  ``'cLN'``: channelwise Layernorm.
+            -  ``'cgLN'``: cumulative global Layernorm.
+            -  Any norm supported by :func:`~.norms.get`
 
     References
-        - [1] : "Conv-TasNet: Surpassing ideal time-frequency magnitude masking
+        [1] : "Conv-TasNet: Surpassing ideal time-frequency magnitude masking
         for speech separation" TASLP 2019 Yi Luo, Nima Mesgarani
         https://arxiv.org/abs/1809.07454
     """
@@ -65,7 +66,7 @@ class Conv1DBlock(nn.Module):
             self.skip_conv = nn.Conv1d(hid_chan, skip_out_chan, 1)
 
     def forward(self, x):
-        """ Input shape [batch, feats, seq]"""
+        r"""Input shape $(batch, feats, seq)$."""
         shared_out = self.shared_block(x)
         res_out = self.res_conv(shared_out)
         if not self.skip_out_chan:
@@ -98,7 +99,7 @@ class TDConvNet(nn.Module):
         mask_act (str, optional): Which non-linear function to generate mask.
 
     References
-        - [1] : "Conv-TasNet: Surpassing ideal time-frequency magnitude masking
+        [1] : "Conv-TasNet: Surpassing ideal time-frequency magnitude masking
         for speech separation" TASLP 2019 Yi Luo, Nima Mesgarani
         https://arxiv.org/abs/1809.07454
     """
@@ -172,15 +173,13 @@ class TDConvNet(nn.Module):
             self.output_act = mask_nl_class()
 
     def forward(self, mixture_w):
-        """
+        r"""Forward.
 
         Args:
-            mixture_w (:class:`torch.Tensor`): Tensor of shape
-                [batch, n_filters, n_frames]
+            mixture_w (:class:`torch.Tensor`): Tensor of shape $(batch, nfilters, nframes)$
 
         Returns:
-            :class:`torch.Tensor`:
-                estimated mask of shape [batch, n_src, n_filters, n_frames]
+            :class:`torch.Tensor`: estimated mask of shape $(batch, nsrc, nfilters, nframes)$
         """
         batch, _, n_frames = mixture_w.size()
         output = self.bottleneck(mixture_w)
@@ -242,18 +241,20 @@ class TDConvNetpp(nn.Module):
         mask_act (str, optional): Which non-linear function to generate mask.
 
     References
-        - [1] : Kavalerov, Ilya et al. “Universal Sound Separation.” in WASPAA 2019
+        [1] : Kavalerov, Ilya et al. “Universal Sound Separation.” in WASPAA 2019
 
-    Notes:
-        The differences wrt to ConvTasnet's TCN are
+    .. note::
+        The differences wrt to ConvTasnet's TCN are:
+
         1. Channel wise layer norm instead of global
         2. Longer-range skip-residual connections from earlier repeat inputs
-            to later repeat inputs after passing them through dense layer.
+           to later repeat inputs after passing them through dense layer.
         3. Learnable scaling parameter after each dense layer. The scaling
-            parameter for the second dense  layer  in  each  convolutional
-            block (which  is  applied  rightbefore the residual connection) is
-            initialized to an exponentially decaying scalar equal to 0.9**L,
-            where L is the layer or block index.
+           parameter for the second dense  layer  in  each  convolutional
+           block (which  is  applied  rightbefore the residual connection) is
+           initialized to an exponentially decaying scalar equal to 0.9**L,
+           where L is the layer or block index.
+
     """
 
     def __init__(
@@ -327,15 +328,13 @@ class TDConvNetpp(nn.Module):
         self.consistency = nn.Linear(out_size, n_src)
 
     def forward(self, mixture_w):
-        """
+        r"""Forward.
 
         Args:
-            mixture_w (:class:`torch.Tensor`): Tensor of shape
-                [batch, n_filters, n_frames]
+            mixture_w (:class:`torch.Tensor`): Tensor of shape $(batch, nfilters, nframes)$
 
         Returns:
-            :class:`torch.Tensor`:
-                estimated mask of shape [batch, n_src, n_filters, n_frames]
+            :class:`torch.Tensor`: estimated mask of shape $(batch, nsrc, nfilters, nframes)$
         """
         batch, n_filters, n_frames = mixture_w.size()
         output = self.bottleneck(mixture_w)
@@ -400,12 +399,12 @@ class DCUNetComplexEncoderBlock(nn.Module):
         stride (Tuple[int, int]): Convolution stride.
         padding (Tuple[int, int]): Convolution padding.
         norm_type (str, optional): Type of normalization to use.
-            See ``asteroid.masknn.norms`` for valid values.
+            See :func:`~asteroid.masknn.norms` for valid values.
         activation (str, optional): Type of activation to use.
-            See ``asteroid.masknn.activations`` for valid values.
+            See :func:`~asteroid.masknn.activations` for valid values.
 
     References
-        - [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
+        [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
         Hyeong-Seok Choi et al. https://arxiv.org/abs/1903.03107
     """
 
@@ -444,12 +443,12 @@ class DCUNetComplexDecoderBlock(nn.Module):
         stride (Tuple[int, int]): Convolution stride.
         padding (Tuple[int, int]): Convolution padding.
         norm_type (str, optional): Type of normalization to use.
-            See ``asteroid.masknn.norms`` for valid values.
+            See :func:`~asteroid.masknn.norms` for valid values.
         activation (str, optional): Type of activation to use.
-            See ``asteroid.masknn.activations`` for valid values.
+            See :func:`~asteroid.masknn.activations` for valid values.
 
     References
-        - [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
+        [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
         Hyeong-Seok Choi et al. https://arxiv.org/abs/1903.03107
     """
 
@@ -487,20 +486,20 @@ class DCUNetComplexDecoderBlock(nn.Module):
 
 
 class DCUMaskNet(BaseDCUMaskNet):
-    """Masking part of DCUNet, as proposed in [1].
+    r"""Masking part of DCUNet, as proposed in [1].
 
     Valid `architecture` values for the ``default_architecture`` classmethod are:
     "Large-DCUNet-20", "DCUNet-20", "DCUNet-16", "DCUNet-10" and "mini".
 
     Valid `fix_length_mode` values are [None, "pad", "trim"].
 
-    Input shape is expected to be [batch, n_freqs, time], with `n_freqs - 1` divisible
-    by `f_0 * f_1 * ... * f_N` where `f_k` are the frequency strides of the encoders,
-    and `time - 1` is divisible by `t_0 * t_1 * ... * t_N` where `t_N` are the time
+    Input shape is expected to be $(batch, nfreqs, time)$, with $nfreqs - 1$ divisible
+    by $f_0 * f_1 * ... * f_N$ where $f_k$ are the frequency strides of the encoders,
+    and $time - 1$ is divisible by $t_0 * t_1 * ... * t_N$ where $t_N$ are the time
     strides of the encoders.
 
     References
-        - [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
+        [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
         Hyeong-Seok Choi et al. https://arxiv.org/abs/1903.03107
     """
 
@@ -578,7 +577,7 @@ class SuDORMRF(nn.Module):
         mask_act (str): Name of output activation.
 
     References
-        - [1] : "Sudo rm -rf: Efficient Networks for Universal Audio Source Separation",
+        [1] : "Sudo rm -rf: Efficient Networks for Universal Audio Source Separation",
         Tzinis et al. MLSP 2020.
     """
 
@@ -672,7 +671,7 @@ class SuDORMRFImproved(nn.Module):
 
 
     References
-        - [1] : "Sudo rm -rf: Efficient Networks for Universal Audio Source Separation",
+        [1] : "Sudo rm -rf: Efficient Networks for Universal Audio Source Separation",
         Tzinis et al. MLSP 2020.
     """
 
@@ -789,8 +788,7 @@ class _BaseUBlock(nn.Module):
 class UBlock(_BaseUBlock):
     """Upsampling block.
 
-    Based on the following principle:
-        ``REDUCE ---> SPLIT ---> TRANSFORM --> MERGE``
+    Based on the following principle: ``REDUCE ---> SPLIT ---> TRANSFORM --> MERGE``
     """
 
     def __init__(self, out_chan=128, in_chan=512, upsampling_depth=4):

--- a/asteroid/masknn/convolutional.py
+++ b/asteroid/masknn/convolutional.py
@@ -399,9 +399,9 @@ class DCUNetComplexEncoderBlock(nn.Module):
         stride (Tuple[int, int]): Convolution stride.
         padding (Tuple[int, int]): Convolution padding.
         norm_type (str, optional): Type of normalization to use.
-            See :func:`~asteroid.masknn.norms` for valid values.
+            See :mod:`~asteroid.masknn.norms` for valid values.
         activation (str, optional): Type of activation to use.
-            See :func:`~asteroid.masknn.activations` for valid values.
+            See :mod:`~asteroid.masknn.activations` for valid values.
 
     References
         [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",
@@ -443,9 +443,9 @@ class DCUNetComplexDecoderBlock(nn.Module):
         stride (Tuple[int, int]): Convolution stride.
         padding (Tuple[int, int]): Convolution padding.
         norm_type (str, optional): Type of normalization to use.
-            See :func:`~asteroid.masknn.norms` for valid values.
+            See :mod:`~asteroid.masknn.norms` for valid values.
         activation (str, optional): Type of activation to use.
-            See :func:`~asteroid.masknn.activations` for valid values.
+            See :mod:`~asteroid.masknn.activations` for valid values.
 
     References
         [1] : "Phase-aware Speech Enhancement with Deep Complex U-Net",

--- a/asteroid/masknn/recurrent.py
+++ b/asteroid/masknn/recurrent.py
@@ -186,7 +186,7 @@ class DPRNNBlock(nn.Module):
         dropout (float, optional): Dropout ratio. Must be in [0, 1].
 
     References
-        - [1] "Dual-path RNN: efficient long sequence modeling for
+        [1] "Dual-path RNN: efficient long sequence modeling for
         time-domain single-channel speech separation", Yi Luo, Zhuo Chen
         and Takuya Yoshioka. https://arxiv.org/abs/1910.06379
     """
@@ -267,7 +267,7 @@ class DPRNN(nn.Module):
         dropout (float, optional): Dropout ratio, must be in [0,1].
 
     References
-        - [1] "Dual-path RNN: efficient long sequence modeling for
+        [1] "Dual-path RNN: efficient long sequence modeling for
         time-domain single-channel speech separation", Yi Luo, Zhuo Chen
         and Takuya Yoshioka. https://arxiv.org/abs/1910.06379
     """
@@ -343,13 +343,13 @@ class DPRNN(nn.Module):
             self.output_act = mask_nl_class()
 
     def forward(self, mixture_w):
-        """
+        r"""Forward.
+
         Args:
-            mixture_w (:class:`torch.Tensor`): Tensor of shape
-                [batch, n_filters, n_frames]
+            mixture_w (:class:`torch.Tensor`): Tensor of shape $(batch, nfilters, nframes)$
+
         Returns:
-            :class:`torch.Tensor`
-                estimated mask of shape [batch, n_src, n_filters, n_frames]
+            :class:`torch.Tensor`: estimated mask of shape $(batch, nsrc, nfilters, nframes)$
         """
         batch, n_filters, n_frames = mixture_w.size()
         output = self.bottleneck(mixture_w)  # [batch, bn_chan, n_frames]
@@ -422,7 +422,7 @@ class LSTMMasker(nn.Module):
         dropout (float, optional): Dropout ratio, must be in [0,1].
 
     References
-        - [1]: Yi Luo et al. "Real-time Single-channel Dereverberation and Separation
+        [1]: Yi Luo et al. "Real-time Single-channel Dereverberation and Separation
         with Time-domain Audio Separation Network", Interspeech 2018
     """
 
@@ -500,22 +500,22 @@ class LSTMMasker(nn.Module):
 
 
 class DCCRMaskNetRNN(nn.Module):
-    """RNN (LSTM) layer between encoders and decoders introduced in [1].
+    r"""RNN (LSTM) layer between encoders and decoders introduced in [1].
 
     Args:
         in_size (int): Number of inputs to the RNN. Must be the product of non-batch,
             non-time dimensions of output shape of last encoder, i.e. if the last
-            encoder output shape is [batch, n_chans, n_freqs, time], `in_size` must be
-            `n_chans * n_freqs`.
+            encoder output shape is $(batch, nchans, nfreqs, time)$, `in_size` must be
+            $nchans * nfreqs$.
         hid_size (int, optional): Number of units in RNN.
         rnn_type (str, optional): Type of RNN to use. See ``SingleRNN`` for valid values.
         n_layers (int, optional): Number of layers used in RNN.
         norm_type (Optional[str], optional): Norm to use after linear.
             See ``asteroid.masknn.norms`` for valid values. (Not used in [1]).
-        rnn_kwargs (optional): Passed to ``SingleRNN``.
+        rnn_kwargs (optional): Passed to :func:`~.recurrent.SingleRNN`.
 
     References
-        - [1] : "DCCRN: Deep Complex Convolution Recurrent Network for Phase-Aware Speech Enhancement",
+        [1] : "DCCRN: Deep Complex Convolution Recurrent Network for Phase-Aware Speech Enhancement",
         Yanxin Hu et al. https://arxiv.org/abs/2008.00264
     """
 
@@ -546,25 +546,25 @@ class DCCRMaskNetRNN(nn.Module):
 
 
 class DCCRMaskNet(BaseDCUMaskNet):
-    """Masking part of DCCRNet, as proposed in [1].
+    r"""Masking part of DCCRNet, as proposed in [1].
 
     Valid `architecture` values for the ``default_architecture`` classmethod are:
-    "DCCRN".
+    "DCCRN" and "mini".
 
     Args:
         encoders (list of length `N` of tuples of (in_chan, out_chan, kernel_size, stride, padding)):
             Arguments of encoders of the u-net
         decoders (list of length `N` of tuples of (in_chan, out_chan, kernel_size, stride, padding))
             Arguments of decoders of the u-net
-        n_freqs (int): Number of frequencies (dim 1) of input to ``.forward()`.
-            Must be divisible by `f_0 * f_1 * ... * f_N` where `f_k` are the frequency
+        n_freqs (int): Number of frequencies (dim 1) of input to ``.forward()``.
+            Must be divisible by $f_0 * f_1 * ... * f_N$ where $f_k$ are the frequency
             strides of the encoders.
 
-    Input shape is expected to be [batch, n_freqs, time], with `n_freqs` divisible
-    by `f_0 * f_1 * ... * f_N` where `f_k` are the frequency strides of the encoders.
+    Input shape is expected to be $(batch, nfreqs, time)$, with $nfreqs$ divisible
+    by $f_0 * f_1 * ... * f_N$ where $f_k$ are the frequency strides of the encoders.
 
     References
-        -[1] : "DCCRN: Deep Complex Convolution Recurrent Network for Phase-Aware Speech Enhancement",
+        [1] : "DCCRN: Deep Complex Convolution Recurrent Network for Phase-Aware Speech Enhancement",
         Yanxin Hu et al. https://arxiv.org/abs/2008.00264
     """
 

--- a/asteroid/metrics.py
+++ b/asteroid/metrics.py
@@ -17,12 +17,12 @@ def get_metrics(
     ignore_metrics_errors=False,
     filename=None,
 ):
-    """Get speech separation/enhancement metrics from mix/clean/estimate.
+    r"""Get speech separation/enhancement metrics from mix/clean/estimate.
 
     Args:
-        mix (np.array): 'Shape(D, N)' or 'Shape(N, )'.
-        clean (np.array): 'Shape(K_source, N)' or 'Shape(N, )'.
-        estimate (np.array): 'Shape(K_target, N)' or 'Shape(N, )'.
+        mix (np.array): mixture array.
+        clean (np.array): reference array.
+        estimate (np.array): estimate array.
         sample_rate (int): sampling rate of the audio clips.
         metrics_list (Union [str, list]): List of metrics to compute.
             Defaults to 'all' (['si_sdr', 'sdr', 'sir', 'sar', 'stoi', 'pesq']).
@@ -34,10 +34,15 @@ def get_metrics(
         filename (str, optional): If computing a metric fails, print this
             filename along with the exception/warning message for debugging purposes.
 
+    Shape:
+        - mix: :math:`(D, N)` or `(N, )`.
+        - clean: :math:`(K\_source, N)` or `(N, )`.
+        - estimate: :math:`(K\_target, N)` or `(N, )`.
+
     Returns:
         dict: Dictionary with all requested metrics, with `'input_'` prefix
-            for metrics at the input (mixture against clean), no prefix at the
-            output (estimate against clean). Output format depends on average.
+        for metrics at the input (mixture against clean), no prefix at the
+        output (estimate against clean). Output format depends on average.
 
     Examples
         >>> import numpy as np
@@ -47,7 +52,7 @@ def get_metrics(
         >>> clean = np.random.randn(2, 16000)
         >>> est = np.random.randn(2, 16000)
         >>> metrics_dict = get_metrics(mix, clean, est, sample_rate=8000,
-        >>>                            metrics_list='all')
+        ...                            metrics_list='all')
         >>> pprint.pprint(metrics_dict)
         {'input_pesq': 1.924380898475647,
          'input_sar': -11.67667585294225,

--- a/asteroid/models/base_models.py
+++ b/asteroid/models/base_models.py
@@ -55,19 +55,19 @@ class BaseModel(torch.nn.Module):
         self.__sample_rate = new_sample_rate
 
     def separate(self, *args, **kwargs):
-        """Convenience for ``asteroid.separate.separate(self, ...)``."""
+        """Convenience for :func:`~asteroid.separate.separate`."""
         return separate.separate(self, *args, **kwargs)
 
     def torch_separate(self, *args, **kwargs):
-        """Convenience for ``asteroid.separate.torch_separate(self, ...)``."""
+        """Convenience for :func:`~asteroid.separate.torch_separate`."""
         return separate.torch_separate(self, *args, **kwargs)
 
     def numpy_separate(self, *args, **kwargs):
-        """Convenience for ``asteroid.separate.numpy_separate(self, ...)``."""
+        """Convenience for :func:`~asteroid.separate.numpy_separate`."""
         return separate.numpy_separate(self, *args, **kwargs)
 
     def file_separate(self, *args, **kwargs):
-        """Convenience for ``asteroid.separate.file_separate(self, ...)``."""
+        """Convenience for :func:`~asteroid.separate.file_separate`."""
         return separate.file_separate(self, *args, **kwargs)
 
     def forward_wav(self, wav, *args, **kwargs):

--- a/asteroid/utils/generic_utils.py
+++ b/asteroid/utils/generic_utils.py
@@ -8,11 +8,11 @@ def has_arg(fn, name):
 
     Args:
         fn (callable): Callable to inspect.
-        name (str): Check if `fn` can be called with `name` as a keyword
+        name (str): Check if ``fn`` can be called with ``name`` as a keyword
             argument.
 
     Returns:
-        bool: whether `fn` accepts a `name` keyword argument.
+        bool: whether ``fn`` accepts a ``name`` keyword argument.
     """
     signature = inspect.signature(fn)
     parameter = signature.parameters.get(name)
@@ -26,8 +26,8 @@ def has_arg(fn, name):
 
 def flatten_dict(d, parent_key="", sep="_"):
     """Flattens a dictionary into a single-level dictionary while preserving
-    parent keys. Taken from https://stackoverflow.com/questions/6027558/
-    flatten-nested-dictionaries-compressing-keys?answertab=votes#tab-top
+    parent keys. Taken from
+    `SO <https://stackoverflow.com/questions/6027558/flatten-nested-dictionaries-compressing-keys>`_
 
     Args:
         d (MutableMapping): Dictionary to be flattened.

--- a/asteroid/utils/hub_utils.py
+++ b/asteroid/utils/hub_utils.py
@@ -28,9 +28,9 @@ def cached_download(filename_or_url):
 
     Args:
         filename_or_url (str): Name of a model as named on the Zenodo Community
-            page (ex: mpariente/ConvTasNet_WHAM!_sepclean), or an URL to a model
-            file (ex: https://zenodo.org/.../model.pth), or a filename
-            that exists locally (ex: local/tmp_model.pth)
+            page (ex: ``"mpariente/ConvTasNet_WHAM!_sepclean"``), or an URL to a model
+            file (ex: ``"https://zenodo.org/.../model.pth"``), or a filename
+            that exists locally (ex: ``"local/tmp_model.pth"``)
 
     Returns:
         str, normalized path to the downloaded (or not) model
@@ -57,7 +57,7 @@ def cached_download(filename_or_url):
 
 
 def url_to_filename(url):
-    """ Consistently convert `url` into a filename. """
+    """Consistently convert ``url`` into a filename."""
     _bytes = url.encode("utf-8")
     _hash = sha256(_bytes)
     filename = _hash.hexdigest()

--- a/asteroid/utils/torch_utils.py
+++ b/asteroid/utils/torch_utils.py
@@ -5,7 +5,7 @@ from torch import nn
 from collections import OrderedDict
 
 
-def to_cuda(tensors):  # pragma: no cover (No CUDA on travis)
+def to_cuda(tensors):  # pragma: no cover
     """Transfer tensor, dict or list of tensors to GPU.
 
     Args:
@@ -14,8 +14,8 @@ def to_cuda(tensors):  # pragma: no cover (No CUDA on travis)
 
     Returns:
         :class:`torch.Tensor`:
-            Same as input but transferred to cuda. Goes through lists and dicts
-            and transfers the torch.Tensor to cuda. Leaves the rest untouched.
+        Same as input but transferred to cuda. Goes through lists and dicts
+        and transfers the torch.Tensor to cuda. Leaves the rest untouched.
     """
     if isinstance(tensors, torch.Tensor):
         return tensors.cuda()
@@ -62,15 +62,15 @@ def get_device(tensor_or_module, default=None):
 
     Args:
         tensor_or_module (Union[torch.Tensor, torch.nn.Module]):
-            The object to get the device from. Can be a `torch.Tensor`,
-            a `torch.nn.Module`, or anything else that has a `device` attribute
-            or a `parameters() -> Iterator[torch.Tensor]` method.
+            The object to get the device from. Can be a ``torch.Tensor``,
+            a ``torch.nn.Module``, or anything else that has a ``device`` attribute
+            or a ``parameters() -> Iterator[torch.Tensor]`` method.
         default (Optional[Union[str, torch.device]]): If the device can not be
-            determined, return this device instead. If `None` (the default),
-            raise a `TypeError` instead.
+            determined, return this device instead. If ``None`` (the default),
+            raise a ``TypeError`` instead.
 
     Returns:
-        torch.device: The device that `tensor_or_module` is on.
+        torch.device: The device that ``tensor_or_module`` is on.
     """
     if hasattr(tensor_or_module, "device"):
         return tensor_or_module.device
@@ -106,8 +106,8 @@ def script_if_tracing(fn):
         fn: A function to compile.
 
     Returns:
-        If called during tracing, a :class:`ScriptFunction` created by `torch.jit.script` is returned.
-        Otherwise, the original function `fn` is returned.
+        If called during tracing, a :class:`ScriptFunction` created by `
+        `torch.jit.script`` is returned. Otherwise, the original function ``fn`` is returned.
     """
 
     @functools.wraps(fn)
@@ -155,11 +155,11 @@ def load_state_dict_in(state_dict, model):
     Returns:
         torch.nn.Module: model with loaded weights.
 
-    .. note:: Keys in a state_dict look like object1.object2.layer_name.weight.etc
+    .. note:: Keys in a state_dict look like ``object1.object2.layer_name.weight.etc``
         We first try to load the model in the classic way.
         If this fail we removes the first left part of the key to obtain
-        object2.layer_name.weight.etc.
-        Blindly loading with strictly=False should be done with some logging
+        ``object2.layer_name.weight.etc``.
+        Blindly loading with ``strictly=False`` should be done with some logging
         of the missing keys in the state_dict and the model.
 
     """
@@ -199,15 +199,16 @@ def are_models_equal(model1, model2):
 
 @script_if_tracing
 def jitable_shape(tensor):
-    """Gets shape of `tensor` as `torch.Tensor` type for jit compiler
+    """Gets shape of ``tensor`` as ``torch.Tensor`` type for jit compiler
 
-    ..note:: Returning `tensor.shape` of `tensor.size()` directly is not torchscript
+    .. note::
+        Returning ``tensor.shape`` of ``tensor.size()`` directly is not torchscript
         compatible as return type would not be supported.
 
     Args:
         tensor (torch.Tensor): Tensor
 
     Returns:
-        torch.Tensor: Shape of `tensor`
+        torch.Tensor: Shape of ``tensor``
     """
     return torch.tensor(tensor.shape)

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ alias run_docs='make clean; make html; firefox build/html/index.html'
 ### Writing good docstrings
 
 - Start with [RST and Sphinx CheatSheet](https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html)
-- Linking to method in a class `:func:~mymodule.myclass.myfunc`.
-([Ref](https://stackoverflow.com/questions/21289806/link-to-class-method-in-python-docstring))
+- [Cross-referencing Python objects](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#cross-referencing-python-objects)
+    - Linking to any method in the package `:func:~mymodule.myclass.myfunc`.
+    - Linking to a method in the class `:meth:mymethod`.
 -

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,4 +33,20 @@ alias run_docs='make clean; make html; firefox build/html/index.html'
 - [Cross-referencing Python objects](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#cross-referencing-python-objects)
     - Linking to any method in the package `:func:~mymodule.myclass.myfunc`.
     - Linking to a method in the class `:meth:mymethod`.
--
+- Writing `Returns` with multiple values
+```python
+def trial(pair_wise_losses):
+    r"""Trial docstring
+
+    Args:
+        pair_wise_losses: there is a dot in the beginning.
+
+    Returns
+        - :class:`torch.Tensor`:
+          The loss corresponding to the best permutation of size $(batch,)$. and
+          if I keep typing? It works?
+
+        - :class:`torch.Tensor`:
+          Notice that those two spaces, not a tab.
+    """
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,11 @@ from the `docs/` folder, that'll be easier.
 ```bash
 alias run_docs='make clean; make html; firefox build/html/index.html'
 ```
+
+
+### Writing good docstrings
+
+- Start with [RST and Sphinx CheatSheet](https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html)
+- Linking to method in a class `:func:~mymodule.myclass.myfunc`.
+([Ref](https://stackoverflow.com/questions/21289806/link-to-class-method-in-python-docstring))
+-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -385,7 +385,8 @@ autodoc_mock_imports = MOCK_REQUIRE_PACKAGES + MOCK_MANUAL_PACKAGES
 autodoc_inherit_docstring = False
 autodoc_default_flags = ["members", "show-inheritance"]
 # Order functions by appearance in source (default 'alphabetical')
-autodoc_member_order = "groupwise"
+autodoc_member_order = "bysource"
+# autodoc_member_order = "groupwise"
 
 
 # autodoc_member_order = 'groupwise'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,8 +54,6 @@ extensions = [
     # w argument 'titles_only'
     # We can either use viewcode, which shows source code in the doc page
     "sphinx.ext.linkcode",
-    # Or linkcode to find the corresponding code in github. Start with viewcode
-    # 'sphinx.ext.linkcode',
     # 'recommonmark',
     "sphinxcontrib.programoutput",
     "m2r2",

--- a/docs/source/package_reference/blocks.rst
+++ b/docs/source/package_reference/blocks.rst
@@ -11,6 +11,11 @@ Recurrent blocks
 .. automodule:: asteroid.masknn.recurrent
    :members:
 
+Attention blocks
+----------------
+.. automodule:: asteroid.masknn.attention
+   :members:
+
 Norms
 -----
 .. automodule:: asteroid.masknn.norms
@@ -20,4 +25,3 @@ Complex number support
 ----------------------
 .. automodule:: asteroid.complex_nn
    :members:
-

--- a/docs/source/package_reference/dsp.rst
+++ b/docs/source/package_reference/dsp.rst
@@ -1,11 +1,28 @@
 DSP Modules
 ===========
 
+.. role:: hidden
+    :class: hidden-section
 
+
+:hidden:`LambdaOverlapAdd`
+~~~~~~~~~~~~~~~~
 .. autoclass:: asteroid.dsp.LambdaOverlapAdd
    :members:
 
+:hidden:`DualPath Processing`
+~~~~~~~~~~~~~~~~
 .. autoclass:: asteroid.dsp.DualPathProcessing
    :members:
 
+:hidden:`Mixture Consistency`
+~~~~~~~~~~~~~~~~
 .. autofunction:: asteroid.dsp.mixture_consistency
+
+:hidden:`VAD`
+~~~~~~~~~~~~~~~~
+.. autofunction:: asteroid.dsp.vad.ebased_vad
+
+:hidden:`Delta Features`
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: asteroid.dsp.deltas

--- a/docs/source/package_reference/filterbanks.rst
+++ b/docs/source/package_reference/filterbanks.rst
@@ -45,12 +45,13 @@ Fixed filterbanks
     :members:
 
 :hidden:`MelGram`
+~~~~~~~~~~~~~~~~~
 .. automodule:: asteroid_filterbanks.melgram_fb
     :members:
 
 :hidden:`MPGT`
 ~~~~~~~~~~~~~~~~
-.. automodule:: asteroid_filterbanks.multiphase_gammatone_fb
+.. autoclass:: asteroid_filterbanks.multiphase_gammatone_fb.MultiphaseGammatoneFB
     :members:
 
 Transforms

--- a/docs/source/package_reference/losses.rst
+++ b/docs/source/package_reference/losses.rst
@@ -15,14 +15,21 @@ Asteroid supports regular Permutation Invariant Training (PIT), it's extension
 using Sinkhorn algorithm (SinkPIT) as well as Mixture Invariant Training (MixIT).
 
 
+:hidden:`PIT`
+~~~~~~~~~~~~~~~~
 .. automodule:: asteroid.losses.pit_wrapper
    :members:
 
+:hidden:`MixIT`
+~~~~~~~~~~~~~~~~
+.. automodule:: asteroid.losses.mixit_wrapper
+   :members:
+
+:hidden:`SinkPIT`
+~~~~~~~~~~~~~~~~
 .. automodule:: asteroid.losses.sinkpit_wrapper
    :members:
 
-.. automodule:: asteroid.losses.mixit_wrapper
-   :members:
 
 Available loss functions
 ------------------------

--- a/docs/source/package_reference/optimizers.rst
+++ b/docs/source/package_reference/optimizers.rst
@@ -4,7 +4,8 @@ Optimizers & Schedulers
 Optimizers
 ----------
 
-Asteroid relies on ``torch_optimizer`` and ``torch`` for optimizers.
+Asteroid relies on `torch_optimizer <https://github.com/jettify/pytorch-optimizer>`_ and
+``torch`` for optimizers.
 We provide a simple ``get`` method that retrieves optimizers from string,
 which makes it easy to specify optimizers from the command line.
 
@@ -44,5 +45,5 @@ Schedulers
 Asteroid provides step-wise learning schedulers, integrable to
 ``pytorch-lightning`` via ``System``.
 
-.. automodule:::: asteroid.engine.schedulers
+.. automodule:: asteroid.engine.schedulers
    :members:

--- a/docs/source/package_reference/system.rst
+++ b/docs/source/package_reference/system.rst
@@ -5,7 +5,8 @@ Lightning Wrapper
 =================
 
 As explained in :ref:`Training and Evaluation`, Asteroid provides a thin wrapper
-on the top of ``PyTorchLightning`` for training your models.
+on the top of `PyTorchLightning <https://github.com/PyTorchLightning/pytorch-lightning>`_
+for training your models.
 
 .. automodule:: asteroid.engine.system
    :members:


### PR DESCRIPTION
Trying to fix the docstrings to render nicely on 0.4.0 release. 

I'm struggling with functions that return multiple things, the docstring is never parsed right when it starts by the return type. 

### Comparing docstrings and visual
1. Looks ok but it doesn't have the dots like in the args.
```python
    def trial(self, pair_wise_losses, perm_reduce=None, **kwargs):
        r"""Trial docstring

        Args:
            pair_wise_losses: there is a dot in the beginning.
            perm_reduce: And it's automatic. 

        Returns:
            :class:`torch.Tensor`: The loss corresponding to the best
            permutation of size $(batch,)$.

            :class:`torch.Tensor`: The indices of the best permutations.
        """
```

![image](https://user-images.githubusercontent.com/18496796/100525952-a6fece80-31c4-11eb-86a1-1dcb5963648b.png)

2. Sphinx is joking with me 
```python 
    def trial(self, pair_wise_losses, perm_reduce=None, **kwargs):
        r"""Trial docstring

        Args:
            pair_wise_losses: there is a dot in the beginning.
            perm_reduce: And it's automatic.

        Returns:
            - :class:`torch.Tensor`: The loss corresponding to the best
              permutation of size $(batch,)$.

            - :class:`torch.Tensor`: The indices of the best permutations.
        """
```

![image](https://user-images.githubusercontent.com/18496796/100525967-d0b7f580-31c4-11eb-8901-d3519955ed18.png)

3. Looks ok but the line is broken
```python
    def trial(self, pair_wise_losses, perm_reduce=None, **kwargs):
        r"""Trial docstring

        Args:
            pair_wise_losses: there is a dot in the beginning.
            perm_reduce: And it's automatic.

        Returns:
            - :class:`torch.Tensor`: The loss corresponding to the best
            permutation of size $(batch,)$.

            - :class:`torch.Tensor`: The indices of the best permutations.
        """
```

![image](https://user-images.githubusercontent.com/18496796/100525972-ed542d80-31c4-11eb-9c7b-35511f54e5e9.png)


4. This is looks great, but cannot start with the type. 
```python
    def trial(self, pair_wise_losses, perm_reduce=None, **kwargs):
        r"""Trial docstring

        Args:
            pair_wise_losses: there is a dot in the beginning.
            perm_reduce: And it's automatic.

        Returns:
            - The loss corresponding to the best permutation of size $(batch,)$.
              (:class:`torch.Tensor`: )

            - The indices of the best permutations (:class:`torch.Tensor`:).
        """
```


![image](https://user-images.githubusercontent.com/18496796/100525984-21c7e980-31c5-11eb-8f79-19ad234cc122.png)


